### PR TITLE
Standardise chainid maps for oracles

### DIFF
--- a/script/WormholeOracle.s.sol
+++ b/script/WormholeOracle.s.sol
@@ -43,12 +43,12 @@ contract DeployWormholeOracle is Script {
         for (uint256 i; i < numMaps; ++i) {
             uint256[2] memory selectMap = map[i];
             uint256 chainId = selectMap[0];
-            if (wormholeOracle.getBlockChainIdToChainIdentifier(chainId) != 0) continue;
+            if (wormholeOracle.reverseChainIdMap(chainId) != 0) continue;
             uint16 messagingProtocolChainIdentifier = uint16(selectMap[1]);
-            if (wormholeOracle.getChainIdentifierToBlockChainId(messagingProtocolChainIdentifier) != 0) continue;
+            if (wormholeOracle.chainIdMap(uint256(messagingProtocolChainIdentifier)) != 0) continue;
 
             vm.broadcast();
-            WormholeOracle(wormholeOracle).setChainMap(messagingProtocolChainIdentifier, chainId);
+            WormholeOracle(wormholeOracle).setChainMap(uint256(messagingProtocolChainIdentifier), chainId);
         }
     }
 }

--- a/snapshots/oracle.json
+++ b/snapshots/oracle.json
@@ -5,5 +5,5 @@
   "bitcoinOutputDispute": "74450",
   "bitcoinVerify": "133934",
   "bitcoinVerifyWithEmbed": "136559",
-  "wormholeOracleSubmit": "14128"
+  "wormholeOracleSubmit": "14084"
 }

--- a/snapshots/settler.json
+++ b/snapshots/settler.json
@@ -11,9 +11,9 @@
   "CompactFinaliseSelf": "128101",
   "CompactFinaliseTo": "128913",
   "IntegrationCoinFill": "112123",
-  "IntegrationCompactFinaliseSelf": "124808",
+  "IntegrationCompactFinaliseSelf": "124831",
   "IntegrationWormholeReceiveMessage": "73550",
-  "IntegrationWormholeSubmit": "42576",
+  "IntegrationWormholeSubmit": "42532",
   "maxTimestamp1": "505",
   "minTimestamp1": "461"
 }

--- a/src/oracles/ChainMap.sol
+++ b/src/oracles/ChainMap.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Ownable } from "solady/auth/Ownable.sol";
+
+/**
+ * @notice Add chainmapping functionality to an oracle.
+ * @dev If this oracle extension is used, it is important that transparent maps are not used; If a chain does not have a
+ * corresponding configured id, it cannot be returned as is. The owner can later change this mapping unexpectedly. This
+ * is not true for configured mappings.
+ */
+abstract contract ChainMap is Ownable {
+    error AlreadySet();
+    error ZeroValue();
+
+    event ChainMapConfigured(uint256 protocolChainIdentifier, uint256 chainId);
+
+    mapping(uint256 protocolChainidentifier => uint256 chainId) public chainIdMap;
+    mapping(uint256 chainId => uint256 protocolChainidentifier) public reverseChainIdMap;
+
+    constructor(
+        address _owner
+    ) {
+        _initializeOwner(_owner);
+    }
+
+    // --- Chain ID Functions --- //
+
+    /**
+     * @dev Wrapper for translating chainIds. Intended to override the implementation of the oracle.
+     * @param protocolId ChainId of a message.
+     * @return chainId "Canonical" chain id.
+     */
+    function _getChainId(
+        uint256 protocolId
+    ) internal view virtual returns (uint256 chainId) {
+        chainId = chainIdMap[protocolId];
+        if (chainId == 0) revert ZeroValue();
+    }
+
+    /**
+     * @notice Sets an immutable map between 2 chain identifiers.
+     * @dev Can only be called once for every chain.
+     * @param protocolChainIdentifier Messaging protocol's chain identifier.
+     * @param chainId "Canonical" chain id. For EVM, should be block.chainid.
+     */
+    function setChainMap(uint256 protocolChainIdentifier, uint256 chainId) external onlyOwner {
+        if (protocolChainIdentifier == 0) revert ZeroValue();
+        if (chainId == 0) revert ZeroValue();
+
+        if (chainIdMap[protocolChainIdentifier] != 0) revert AlreadySet();
+        if (reverseChainIdMap[chainId] != 0) revert AlreadySet();
+
+        chainIdMap[protocolChainIdentifier] = chainId;
+        reverseChainIdMap[chainId] = protocolChainIdentifier;
+
+        emit ChainMapConfigured(protocolChainIdentifier, chainId);
+    }
+}

--- a/src/oracles/polymer/PolymerOracle.sol
+++ b/src/oracles/polymer/PolymerOracle.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import { Ownable } from "solady/auth/Ownable.sol";
 import { LibBytes } from "solady/utils/LibBytes.sol";
 
 import { MandateOutput, MandateOutputEncodingLib } from "../../libs/MandateOutputEncodingLib.sol";
@@ -12,67 +11,19 @@ import { ICrossL2Prover } from "./ICrossL2Prover.sol";
 /**
  * @notice Polymer Oracle that uses the fill event to reconstruct the payload for verification.
  */
-contract PolymerOracle is BaseOracle, Ownable {
-    error AlreadySet();
-    error ZeroValue();
-
-    event MapMessagingProtocolIdentifierToChainId(uint32 messagingProtocolIdentifier, uint256 chainId);
-
-    mapping(uint32 messagingProtocolChainIdentifier => uint256 blockChainId) _chainIdentifierToBlockChainId;
-    /**
-     * @dev The map is bi-directional.
-     */
-    mapping(uint256 blockChainId => uint32 messagingProtocolChainIdentifier) _blockChainIdToChainIdentifier;
-
+contract PolymerOracle is BaseOracle {
     ICrossL2Prover CROSS_L2_PROVER;
 
-    constructor(address _owner, address crossL2Prover) {
-        _initializeOwner(_owner);
+    constructor(
+        address crossL2Prover
+    ) {
         CROSS_L2_PROVER = ICrossL2Prover(crossL2Prover);
     }
 
-    // --- Chain ID Functions --- //
-
-    /**
-     * @notice Sets an immutable map of the identifier messaging protocols use to chain ids.
-     * @dev Can only be called once for every chain.
-     * @param messagingProtocolChainIdentifier Messaging provider identifier for a chain.
-     * @param chainId Most common identifier for a chain. For EVM, it can often be accessed through block.chainid.
-     */
-    function setChainMap(uint32 messagingProtocolChainIdentifier, uint256 chainId) external onlyOwner {
-        // Check that the inputs haven't been mistakenly called with 0 values.
-        if (messagingProtocolChainIdentifier == 0) revert ZeroValue();
-        if (chainId == 0) revert ZeroValue();
-
-        // This call only allows setting either value once, then they are done for.
-        // We need to check if they are currently unset.
-        if (_chainIdentifierToBlockChainId[messagingProtocolChainIdentifier] != 0) revert AlreadySet();
-        if (_blockChainIdToChainIdentifier[chainId] != 0) revert AlreadySet();
-
-        _chainIdentifierToBlockChainId[messagingProtocolChainIdentifier] = chainId;
-        _blockChainIdToChainIdentifier[chainId] = messagingProtocolChainIdentifier;
-
-        emit MapMessagingProtocolIdentifierToChainId(messagingProtocolChainIdentifier, chainId);
-    }
-
-    /**
-     * @param messagingProtocolChainIdentifier Messaging protocol chain identifier
-     * @return chainId Common chain identifier
-     */
-    function getChainIdentifierToBlockChainId(
-        uint32 messagingProtocolChainIdentifier
-    ) external view returns (uint256 chainId) {
-        return _chainIdentifierToBlockChainId[messagingProtocolChainIdentifier];
-    }
-
-    /**
-     * @param chainId Common chain identifier
-     * @return messagingProtocolChainIdentifier Messaging protocol chain identifier.
-     */
-    function getBlockChainIdToChainIdentifier(
-        uint256 chainId
-    ) external view returns (uint32 messagingProtocolChainIdentifier) {
-        return _blockChainIdToChainIdentifier[chainId];
+    function _getChainId(
+        uint256 protocolId
+    ) internal view virtual returns (uint256 chainId) {
+        return protocolId;
     }
 
     function _proofPayloadHash(
@@ -100,8 +51,7 @@ contract PolymerOracle is BaseOracle, Ownable {
         bytes32 payloadHash = _proofPayloadHash(orderId, solver, timestamp, output);
 
         // Convert the Polymer ChainID into the canonical chainId.
-        uint256 remoteChainId = _chainIdentifierToBlockChainId[chainId];
-        if (remoteChainId == 0) revert ZeroValue();
+        uint256 remoteChainId = _getChainId(uint256(chainId));
 
         bytes32 application = bytes32(uint256(uint160(emittingContract)));
         _attestations[remoteChainId][bytes32(uint256(uint160(address(this))))][application][payloadHash] = true;

--- a/src/oracles/polymer/PolymerOracleMapped.sol
+++ b/src/oracles/polymer/PolymerOracleMapped.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { ChainMap } from "../ChainMap.sol";
+import { PolymerOracle } from "./PolymerOracle.sol";
+
+/**
+ * @notice Polymer Oracle with mapped chainIds
+ */
+contract PolymerOracleMapped is ChainMap, PolymerOracle {
+    constructor(address _owner, address crossL2Prover) ChainMap(_owner) PolymerOracle(crossL2Prover) { }
+
+    function _getChainId(
+        uint256 protocolId
+    ) internal view override(ChainMap, PolymerOracle) returns (uint256 chainId) {
+        chainId = ChainMap._getChainId(protocolId);
+    }
+}

--- a/src/oracles/wormhole/WormholeOracle.sol
+++ b/src/oracles/wormhole/WormholeOracle.sol
@@ -8,6 +8,7 @@ import { IPayloadCreator } from "../../interfaces/IPayloadCreator.sol";
 import { MessageEncodingLib } from "../../libs/MessageEncodingLib.sol";
 
 import { BaseOracle } from "../BaseOracle.sol";
+import { ChainMap } from "../ChainMap.sol";
 
 import { WormholeVerifier } from "./external/callworm/WormholeVerifier.sol";
 import { IWormhole } from "./interfaces/IWormhole.sol";
@@ -19,109 +20,45 @@ import { IWormhole } from "./interfaces/IWormhole.sol";
  * @dev The contract is mostly trustless but requires someone to translate Wormhole chainIds into
  * proper chainIds. These maps once set are immutable and trustless.
  */
-contract WormholeOracle is BaseOracle, WormholeVerifier, Ownable {
-    error AlreadySet();
+contract WormholeOracle is ChainMap, BaseOracle, WormholeVerifier {
     error NotAllPayloadsValid();
-    error ZeroValue();
 
-    event MapMessagingProtocolIdentifierToChainId(uint16 messagingProtocolIdentifier, uint256 chainId);
-
-    /**
-     * @notice Takes a chain identifier from Wormhole and translates it to "ordinary" chain ids.
-     * @dev This allows us to translate incoming messages from messaging protocols to easy to
-     * understand chain ids that match the most common and available identifier for chains. (their actual
-     * identifier) rather than an arbitrary index which is what most messaging protocols use.
-     */
-    mapping(uint16 messagingProtocolChainIdentifier => uint256 blockChainId) _chainIdentifierToBlockChainId;
-    /**
-     * @dev The map is bi-directional.
-     */
-    mapping(uint256 blockChainId => uint16 messagingProtocolChainIdentifier) _blockChainIdToChainIdentifier;
-
-    /**
-     * @dev Wormhole generally defines 15 to be equal to Finality
-     */
+    /// @dev Wormhole generally defines 15 to be equal to Finality
     uint8 constant WORMHOLE_CONSISTENCY = 15;
 
     IWormhole public immutable WORMHOLE;
 
-    constructor(address _owner, address _wormhole) payable WormholeVerifier(_wormhole) {
-        _initializeOwner(_owner);
+    constructor(address _owner, address _wormhole) payable ChainMap(_owner) WormholeVerifier(_wormhole) {
         WORMHOLE = IWormhole(_wormhole);
     }
 
-    // --- Chain ID Functions --- //
-
-    /**
-     * @notice Sets an immutable map of the identifier messaging protocols use to chain ids.
-     * @dev Can only be called once for every chain.
-     * @param messagingProtocolChainIdentifier Messaging provider identifier for a chain.
-     * @param chainId Most common identifier for a chain. For EVM, it can often be accessed through block.chainid.
-     */
-    function setChainMap(uint16 messagingProtocolChainIdentifier, uint256 chainId) external onlyOwner {
-        // Check that the inputs haven't been mistakenly called with 0 values.
-        if (messagingProtocolChainIdentifier == 0) revert ZeroValue();
-        if (chainId == 0) revert ZeroValue();
-
-        // This call only allows setting either value once, then they are done for.
-        // We need to check if they are currently unset.
-        if (_chainIdentifierToBlockChainId[messagingProtocolChainIdentifier] != 0) revert AlreadySet();
-        if (_blockChainIdToChainIdentifier[chainId] != 0) revert AlreadySet();
-
-        _chainIdentifierToBlockChainId[messagingProtocolChainIdentifier] = chainId;
-        _blockChainIdToChainIdentifier[chainId] = messagingProtocolChainIdentifier;
-
-        emit MapMessagingProtocolIdentifierToChainId(messagingProtocolChainIdentifier, chainId);
-    }
-
-    /**
-     * @param messagingProtocolChainIdentifier Messaging protocol chain identifier
-     * @return chainId Common chain identifier
-     */
-    function getChainIdentifierToBlockChainId(
-        uint16 messagingProtocolChainIdentifier
-    ) external view returns (uint256 chainId) {
-        return _chainIdentifierToBlockChainId[messagingProtocolChainIdentifier];
-    }
-
-    /**
-     * @param chainId Common chain identifier
-     * @return messagingProtocolChainIdentifier Messaging protocol chain identifier.
-     */
-    function getBlockChainIdToChainIdentifier(
-        uint256 chainId
-    ) external view returns (uint16 messagingProtocolChainIdentifier) {
-        return _blockChainIdToChainIdentifier[chainId];
-    }
-
-    // --- Sending Proofs & Generalised Incentives --- //
+    // --- Sending Proofs --- //
 
     /**
      * @notice Takes proofs that have been marked as valid by a source and submits them to Wormhole for broadcast.
-     * @param proofSource Application that has payloads that are marked as valid.
-     * @param payloads List of payloads that are checked for validity against the application and broadcasted.
+     * @param source Application that has payloads that are marked as valid.
+     * @param payloads List of payloads to broadcast.
+     * @return refund If too much value has been sent, the excess will be returned to msg.sender.
      */
-    function submit(address proofSource, bytes[] calldata payloads) public payable returns (uint256 refund) {
-        // Check if the payloads are valid.
+    function submit(address source, bytes[] calldata payloads) public payable returns (uint256 refund) {
         uint256 numPayloads = payloads.length;
         bytes32[] memory payloadHashes = new bytes32[](numPayloads);
         for (uint256 i; i < numPayloads; ++i) {
             payloadHashes[i] = keccak256(payloads[i]);
         }
-        if (!IPayloadCreator(proofSource).arePayloadsValid(payloadHashes)) revert NotAllPayloadsValid();
-
-        // Payloads are good. We can submit them on behalf of proofSource.
-        return _submit(proofSource, payloads);
+        if (!IPayloadCreator(source).arePayloadsValid(payloadHashes)) revert NotAllPayloadsValid();
+        return _submit(source, payloads);
     }
 
     // --- Wormhole Logic --- //
 
     /**
-     * @notice Submits a proof the associated messaging protocol.
-     * @dev Refunds excess value to msg.sender.
+     * @notice Submits packaged payloads to Wormhole.
+     * @param source Application that has payloads that are marked as valid.
+     * @param payloads List of payloads that have been checked for validity and are to be broadcasted.
+     * @return refund If too much value has been sent, the excess will be returned to msg.sender.
      */
     function _submit(address source, bytes[] calldata payloads) internal returns (uint256 refund) {
-        // This call fails if fillDeadlines.length < outputs.length
         bytes memory message = MessageEncodingLib.encodeMessage(bytes32(uint256(uint160(source))), payloads);
 
         uint256 packageCost = WORMHOLE.messageFee();
@@ -135,25 +72,20 @@ contract WormholeOracle is BaseOracle, WormholeVerifier, Ownable {
     }
 
     /**
-     * @notice Takes a wormhole VAA, which is expected to be from another WormholeOracle implementation
-     * and stores attestations of the hash of the payloads contained within the VAA message.
+     * @notice Takes a wormhole VAA and stores attestations of the contained payloads.
+     * @param rawMessage Wormhole VAA
      */
     function receiveMessage(
         bytes calldata rawMessage
     ) external {
-        // Verify Packet and return message identifiers that Wormhole attached.
         (uint16 remoteMessagingProtocolChainIdentifier, bytes32 remoteSenderIdentifier, bytes calldata message) =
             _verifyPacket(rawMessage);
-        // Decode message.
         (bytes32 application, bytes32[] memory payloadHashes) = MessageEncodingLib.decodeMessage(message);
 
-        // Map remoteMessagingProtocolChainIdentifier to canonical chain id. This ensures we use canonical ids.
-        uint256 remoteChainId = _chainIdentifierToBlockChainId[remoteMessagingProtocolChainIdentifier];
-        if (remoteChainId == 0) revert ZeroValue();
+        uint256 remoteChainId = _getChainId(uint256(remoteMessagingProtocolChainIdentifier));
 
         uint256 numPayloads = payloadHashes.length;
         for (uint256 i; i < numPayloads; ++i) {
-            // Store payload attestations;
             bytes32 payloadHash = payloadHashes[i];
             _attestations[remoteChainId][remoteSenderIdentifier][application][payloadHash] = true;
 
@@ -162,12 +94,14 @@ contract WormholeOracle is BaseOracle, WormholeVerifier, Ownable {
     }
 
     /**
-     * @dev _message is the entire Wormhole VAA. It contains both the proof & the message as a slice.
+     * @param _message Wormhole VAA.
+     * @return sourceIdentifier Wormhole chainId of the chain the message was emitted from.
+     * @return implementationIdentifier Emitter of the message.
+     * @return message_ Sent message contained within the VAA as a slice.
      */
     function _verifyPacket(
         bytes calldata _message
     ) internal view returns (uint16 sourceIdentifier, bytes32 implementationIdentifier, bytes calldata message_) {
-        // Decode & verify the VAA.
         // This uses the custom verification logic found in ./external/callworm/WormholeVerifier.sol.
         (sourceIdentifier, implementationIdentifier, message_) = parseAndVerifyVM(_message);
     }

--- a/test/oracle/wormhole/WormholeOracle.t.sol
+++ b/test/oracle/wormhole/WormholeOracle.t.sol
@@ -15,19 +15,19 @@ contract WormholeOracleTest is Test {
     function test_set_chain_map(uint16 messagingProtocolChainIdentifier, uint256 chainId) external {
         vm.assume(messagingProtocolChainIdentifier != 0);
         vm.assume(chainId != 0);
-        wormholeOracle.setChainMap(messagingProtocolChainIdentifier, chainId);
+        wormholeOracle.setChainMap(uint256(messagingProtocolChainIdentifier), chainId);
 
-        uint256 readChainId = wormholeOracle.getChainIdentifierToBlockChainId(messagingProtocolChainIdentifier);
+        uint256 readChainId = wormholeOracle.chainIdMap(uint256(messagingProtocolChainIdentifier));
         assertEq(readChainId, chainId);
 
-        uint16 readMessagingProtocolChainIdentifier = wormholeOracle.getBlockChainIdToChainIdentifier(chainId);
+        uint16 readMessagingProtocolChainIdentifier = uint16(wormholeOracle.reverseChainIdMap(chainId));
         assertEq(readMessagingProtocolChainIdentifier, messagingProtocolChainIdentifier);
 
         vm.expectRevert(abi.encodeWithSignature("AlreadySet()"));
-        wormholeOracle.setChainMap(messagingProtocolChainIdentifier, chainId);
+        wormholeOracle.setChainMap(uint256(messagingProtocolChainIdentifier), chainId);
 
         vm.expectRevert(abi.encodeWithSignature("AlreadySet()"));
-        wormholeOracle.setChainMap(messagingProtocolChainIdentifier, 1);
+        wormholeOracle.setChainMap(uint256(messagingProtocolChainIdentifier), 1);
 
         vm.expectRevert(abi.encodeWithSignature("AlreadySet()"));
         wormholeOracle.setChainMap(1, chainId);


### PR DESCRIPTION
**Goal**
Provide an ownerless and configless allowing for a potential 100% deterministic deployment.

Secondary: Standardises chainId mapping functionality.

**Description**
There may be proposed a standard for chainIds (ignoring the fact that there already is one but messaging protocols are ignoring it), even for non-EVM chains. If messaging protocols relay messages using that standard, then there is no need to map their chainIds. This PR separates the logic of mapping chainIds from that of oracles.

Polymer is one such oracle for EVM chains.