### PR TITLE
Optimize output settler by using a single storage slot

### DIFF
--- a/snapshots/inputSettler.json
+++ b/snapshots/inputSettler.json
@@ -7,13 +7,13 @@
   "7683open": "86728",
   "7683openFor": "134449",
   "BasePurchaseOrder": "137111",
-  "CompactFinaliseFor": "139560",
-  "CompactFinaliseSelf": "130980",
-  "CompactFinaliseTo": "130980",
+  "CompactFinaliseFor": "139724",
+  "CompactFinaliseSelf": "131144",
+  "CompactFinaliseTo": "131144",
   "IntegrationCoinFill": "89729",
-  "IntegrationCompactFinaliseSelf": "127613",
+  "IntegrationCompactFinaliseSelf": "127777",
   "IntegrationWormholeReceiveMessage": "73514",
-  "IntegrationWormholeSubmit": "46174",
+  "IntegrationWormholeSubmit": "46206",
   "maxTimestamp1": "505",
   "minTimestamp1": "461"
 }

--- a/snapshots/inputSettler.json
+++ b/snapshots/inputSettler.json
@@ -10,10 +10,10 @@
   "CompactFinaliseFor": "139560",
   "CompactFinaliseSelf": "130980",
   "CompactFinaliseTo": "130980",
-  "IntegrationCoinFill": "112123",
+  "IntegrationCoinFill": "89729",
   "IntegrationCompactFinaliseSelf": "127613",
-  "IntegrationWormholeReceiveMessage": "73550",
-  "IntegrationWormholeSubmit": "42532",
+  "IntegrationWormholeReceiveMessage": "73514",
+  "IntegrationWormholeSubmit": "46174",
   "maxTimestamp1": "505",
   "minTimestamp1": "461"
 }

--- a/snapshots/oracle.json
+++ b/snapshots/oracle.json
@@ -5,5 +5,5 @@
   "bitcoinOutputDispute": "74450",
   "bitcoinVerify": "133931",
   "bitcoinVerifyWithEmbed": "136556",
-  "wormholeOracleSubmit": "14084"
+  "wormholeOracleSubmit": "16118"
 }

--- a/snapshots/oracle.json
+++ b/snapshots/oracle.json
@@ -5,5 +5,5 @@
   "bitcoinOutputDispute": "74450",
   "bitcoinVerify": "133931",
   "bitcoinVerifyWithEmbed": "136556",
-  "wormholeOracleSubmit": "16118"
+  "wormholeOracleSubmit": "16150"
 }

--- a/snapshots/outputSettler.json
+++ b/snapshots/outputSettler.json
@@ -3,5 +3,5 @@
   "outputSettlerCoinFillDutchAuction": "84618",
   "outputSettlerCoinFillExclusive": "84811",
   "outputSettlerCoinFillExclusiveDutchAuction": "85558",
-  "outputSettlerCoinfillOrderOutputs": "119653"
+  "outputSettlerCoinfillOrderOutputs": "119675"
 }

--- a/snapshots/outputSettler.json
+++ b/snapshots/outputSettler.json
@@ -1,7 +1,7 @@
 {
-  "outputSettlerCoinFill": "105379",
-  "outputSettlerCoinFillDutchAuction": "107012",
-  "outputSettlerCoinFillExclusive": "107205",
-  "outputSettlerCoinFillExclusiveDutchAuction": "107952",
-  "outputSettlerCoinfillOrderOutputs": "164383"
+  "outputSettlerCoinFill": "82985",
+  "outputSettlerCoinFillDutchAuction": "84618",
+  "outputSettlerCoinFillExclusive": "84811",
+  "outputSettlerCoinFillExclusiveDutchAuction": "85558",
+  "outputSettlerCoinfillOrderOutputs": "119653"
 }

--- a/src/interfaces/IOracle.sol
+++ b/src/interfaces/IOracle.sol
@@ -3,18 +3,9 @@ pragma solidity >=0.8.0;
 
 interface IOracle {
     /**
-     * @notice Check if some data has been attested to on the remote chain.
-     * @param remoteChainId ChainId of data origin.
-     * @param remoteOracle Attestor on the data origin chain.
-     * @param application Application that the data originated from.
-     * @param dataHash Hash of data.
+     * @notice Error thrown when a proof is not valid.
      */
-    function isProven(
-        uint256 remoteChainId,
-        bytes32 remoteOracle,
-        bytes32 application,
-        bytes32 dataHash
-    ) external view returns (bool);
+    error NotProven();
 
     /**
      * @notice Check if a series of data has been attested to.

--- a/src/interfaces/IPayloadCreator.sol
+++ b/src/interfaces/IPayloadCreator.sol
@@ -5,7 +5,13 @@ pragma solidity >=0.8.0;
  * @notice Interface for exposing data that oracles can bridge cross-chain.
  */
 interface IPayloadCreator {
+    struct FillRecord {
+        bytes32 orderId;
+        bytes32 outputHash;
+        bytes32 payloadHash;
+    }
+
     function arePayloadsValid(
-        bytes32[] calldata payloads
+        FillRecord[] calldata fills
     ) external view returns (bool);
 }

--- a/src/interfaces/IPayloadCreator.sol
+++ b/src/interfaces/IPayloadCreator.sol
@@ -11,7 +11,10 @@ interface IPayloadCreator {
         bytes32 payloadHash;
     }
 
+    /// @notice Check if a series of fill records are valid.
+    /// @param fills Encoded fill records to validate
+    /// @return bool Whether all fill records are valid
     function arePayloadsValid(
-        FillRecord[] calldata fills
+        bytes calldata fills
     ) external view returns (bool);
 }

--- a/src/oracles/BaseOracle.sol
+++ b/src/oracles/BaseOracle.sol
@@ -9,7 +9,6 @@ import { IOracle } from "../interfaces/IOracle.sol";
  */
 abstract contract BaseOracle is IOracle {
     error NotDivisible(uint256 value, uint256 divisor);
-    error NotProven();
 
     event OutputProven(uint256 chainid, bytes32 remoteIdentifier, bytes32 application, bytes32 payloadHash);
 

--- a/src/output/BaseOutputSettler.sol
+++ b/src/output/BaseOutputSettler.sol
@@ -129,7 +129,7 @@ abstract contract BaseOutputSettler is IPayloadCreator {
         if (fillDeadline < block.timestamp) revert FillDeadline();
 
         uint256 numOutputs = outputs.length;
-        for (uint256 i = 1; i < numOutputs; ++i) {
+        for (uint256 i = 0; i < numOutputs; ++i) {
             _fill(orderId, outputs[i], proposedSolver);
         }
     }

--- a/src/output/BaseOutputSettler.sol
+++ b/src/output/BaseOutputSettler.sol
@@ -15,16 +15,16 @@ import { BaseOracle } from "../oracles/BaseOracle.sol";
  * Does not support native coins.
  * This base output settler implements logic to work as both a PayloadCreator (for oracles) and as an oracle itself.
  */
-abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
+abstract contract BaseOutputSettler is IPayloadCreator {
     error FillDeadline();
-    error FilledBySomeoneElse(bytes32 solver);
+    error AlreadyFilled(bytes32 orderId, bytes32 outputHash);
     error ZeroValue();
 
     /**
-     * @notice Sets outputs as filled by their solver identifier, such that outputs won't be filled twice.
+     * @notice Sets outputs as filled storing their payload hash, such that outputs won't be filled twice.
      * @dev Is not used for validating payloads, BaseOracle::_attestations is used instead.
      */
-    mapping(bytes32 orderId => mapping(bytes32 outputHash => bytes32 solver)) public filledOutputs;
+    mapping(bytes32 orderId => mapping(bytes32 outputHash => bytes32 payloadHash)) internal _fillRecords;
 
     /**
      * @notice Output has been filled.
@@ -38,13 +38,8 @@ abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
      * @param orderId Input chain order identifier. Is used as is, not checked for validity.
      * @param output The given output to fill. Is expected to belong to a greater order identified by orderId
      * @param proposedSolver Solver identifier to be sent to input chain.
-     * @return actualSolver Solver that filled the order. Tokens are only collected if equal to proposedSolver.
      */
-    function _fill(
-        bytes32 orderId,
-        MandateOutput calldata output,
-        bytes32 proposedSolver
-    ) internal virtual returns (bytes32);
+    function _fill(bytes32 orderId, MandateOutput calldata output, bytes32 proposedSolver) internal virtual;
 
     /**
      * @notice Performs basic validation and fills output is unfilled.
@@ -60,32 +55,26 @@ abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
      * @param output Given output to fill. Is expected to belong to a greater order identified by orderId
      * @param outputAmount Amount to fill after order evaluation. Will be instead of output.amount.
      * @param proposedSolver Solver identifier to be sent to input chain.
-     * @return bytes32 Solver that filled the order. Tokens are only collected if equal to proposedSolver.
      */
     function _fill(
         bytes32 orderId,
         MandateOutput calldata output,
         uint256 outputAmount,
         bytes32 proposedSolver
-    ) internal virtual returns (bytes32) {
+    ) internal virtual {
         if (proposedSolver == bytes32(0)) revert ZeroValue();
         OutputVerificationLib._isThisChain(output.chainId);
         OutputVerificationLib._isThisOutputSettler(output.settler);
 
         bytes32 outputHash = MandateOutputEncodingLib.getMandateOutputHash(output);
-        bytes32 existingSolver = filledOutputs[orderId][outputHash];
-        if (existingSolver != bytes32(0)) return existingSolver; // Early return if already solved.
-        // The above and below lines act as a local re-entry check.
-        filledOutputs[orderId][outputHash] = proposedSolver;
+        bytes32 existing = _fillRecords[orderId][outputHash];
 
-        // Set the output attestation as true. This allows the output settler to act as an oracle. Note that the payload
-        // contains the current timestamp. This timestamp needs to be collected from the event (or tx) to be able to
-        // reproduce the payload(hash)
-        bytes32 dataHash = keccak256(
+        if (existing != bytes32(0)) revert AlreadyFilled(orderId, outputHash);
+
+        bytes32 payloadHash = keccak256(
             MandateOutputEncodingLib.encodeFillDescription(proposedSolver, orderId, uint32(block.timestamp), output)
         );
-        _attestations[block.chainid][bytes32(uint256(uint160(address(this))))][bytes32(uint256(uint160(address(this))))][dataHash]
-        = true;
+        _fillRecords[orderId][outputHash] = payloadHash;
 
         // Storage has been set. Fill the output.
         address recipient = address(uint160(uint256(output.recipient)));
@@ -93,7 +82,6 @@ abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
         if (output.call.length > 0) IOIFCallback(recipient).outputFilled(output.token, outputAmount, output.call);
 
         emit OutputFilled(orderId, proposedSolver, uint32(block.timestamp), output);
-        return proposedSolver;
     }
 
     // --- External Solver Interface --- //
@@ -104,16 +92,15 @@ abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
      * @param orderId Input chain order identifier. Is used as is, not checked for validity.
      * @param output Given output to fill. Is expected to belong to a greater order identified by orderId.
      * @param proposedSolver Solver identifier to be sent to input chain.
-     * @return bytes32 Solver that filled the order. Tokens are only collected if equal to proposedSolver.
      */
     function fill(
         uint32 fillDeadline,
         bytes32 orderId,
         MandateOutput calldata output,
         bytes32 proposedSolver
-    ) external virtual returns (bytes32) {
+    ) external virtual {
         if (fillDeadline < block.timestamp) revert FillDeadline();
-        return _fill(orderId, output, proposedSolver);
+        _fill(orderId, output, proposedSolver);
     }
 
     // -- Batch Solving -- //
@@ -141,9 +128,6 @@ abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
     ) external {
         if (fillDeadline < block.timestamp) revert FillDeadline();
 
-        bytes32 actualSolver = _fill(orderId, outputs[0], proposedSolver);
-        if (actualSolver != proposedSolver) revert FilledBySomeoneElse(actualSolver);
-
         uint256 numOutputs = outputs.length;
         for (uint256 i = 1; i < numOutputs; ++i) {
             _fill(orderId, outputs[i], proposedSolver);
@@ -169,29 +153,19 @@ abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
     // --- IPayloadCreator --- //
 
     /**
-     * @notice Helper function to check whether a payload hash is valid.
-     * @param payloadHash keccak256 hash of the relevant payload.
-     * @return bool Whether or not the payload has been recorded as filled.
+     * @notice Check if a series of fill records are valid.
+     * @param fills Array of fill records to validate
+     * @return bool Whether all fill records are valid
      */
-    function _isPayloadValid(
-        bytes32 payloadHash
-    ) internal view virtual returns (bool) {
-        return _attestations[block.chainid][bytes32(uint256(uint160(address(this))))][bytes32(
-            uint256(uint160(address(this)))
-        )][payloadHash];
-    }
-
-    /**
-     * @notice Returns whether a set of payload hashes have been approved by this contract.
-     */
+    // TODO: Use an opaque bytes or bytes32 array instead of a struct array.
     function arePayloadsValid(
-        bytes32[] calldata payloadHashes
+        FillRecord[] calldata fills
     ) external view returns (bool) {
-        uint256 numPayloads = payloadHashes.length;
-        bool accumulator = true;
-        for (uint256 i; i < numPayloads; ++i) {
-            accumulator = accumulator && _isPayloadValid(payloadHashes[i]);
+        uint256 numFills = fills.length;
+        for (uint256 i; i < numFills; ++i) {
+            FillRecord calldata fillRecord = fills[i];
+            if (_fillRecords[fillRecord.orderId][fillRecord.outputHash] != fillRecord.payloadHash) return false;
         }
-        return accumulator;
+        return true;
     }
 }

--- a/src/output/BaseOutputSettler.sol
+++ b/src/output/BaseOutputSettler.sol
@@ -12,8 +12,10 @@ import { IOracle } from "../interfaces/IOracle.sol";
 
 /**
  * @notice Base Output Settler implementing logic for settling outputs.
- * Does not support native coins.
- * This base output settler implements logic to work as both a PayloadCreator (for oracles) and as an oracle itself.
+ * @dev Does not support native coins.
+ * @dev This base output settler implements logic to work as both a PayloadCreator (for oracles) and as an oracle
+ * itself. The output settler can be used as an oracle for same-chain intents. This is achieved by setting the
+ * `localOracle` of the order to the output settler address.
  */
 abstract contract BaseOutputSettler is IPayloadCreator, IOracle {
     error FillDeadline();

--- a/src/output/BaseOutputSettler.sol
+++ b/src/output/BaseOutputSettler.sol
@@ -154,16 +154,18 @@ abstract contract BaseOutputSettler is IPayloadCreator {
 
     /**
      * @notice Check if a series of fill records are valid.
-     * @param fills Array of fill records to validate
+     * @param fills Encoded fill records to validate
      * @return bool Whether all fill records are valid
      */
-    // TODO: Use an opaque bytes or bytes32 array instead of a struct array.
     function arePayloadsValid(
-        FillRecord[] calldata fills
+        bytes calldata fills
     ) external view returns (bool) {
-        uint256 numFills = fills.length;
+        // Decode the opaque bytes into FillRecord array
+        FillRecord[] memory fillRecords = abi.decode(fills, (FillRecord[]));
+
+        uint256 numFills = fillRecords.length;
         for (uint256 i; i < numFills; ++i) {
-            FillRecord calldata fillRecord = fills[i];
+            FillRecord memory fillRecord = fillRecords[i];
             if (_fillRecords[fillRecord.orderId][fillRecord.outputHash] != fillRecord.payloadHash) return false;
         }
         return true;

--- a/src/output/coin/OutputSettlerCoin.sol
+++ b/src/output/coin/OutputSettlerCoin.sol
@@ -114,14 +114,9 @@ contract OutputSettlerCoin is BaseOutputSettler {
      * @param orderId Input chain order identifier.
      * @param output The given output to fill.
      * @param proposedSolver Solver identifier to be sent to origin chain.
-     * @return actualSolver may differ from proposed solver if output has already been filled.
      */
-    function _fill(
-        bytes32 orderId,
-        MandateOutput calldata output,
-        bytes32 proposedSolver
-    ) internal override returns (bytes32) {
+    function _fill(bytes32 orderId, MandateOutput calldata output, bytes32 proposedSolver) internal override {
         uint256 amount = _orderType(output, proposedSolver);
-        return _fill(orderId, output, amount, proposedSolver);
+        _fill(orderId, output, amount, proposedSolver);
     }
 }

--- a/test/input/compact/InputSettlerCompact.t.sol
+++ b/test/input/compact/InputSettlerCompact.t.sol
@@ -63,6 +63,9 @@ contract InputSettlerCompactTest is InputSettlerCompactTestBase {
             timestamps[i] = orderFulfillmentDescription[i].timestamp;
             MandateOutputs[i] = orderFulfillmentDescription[i].MandateOutput;
 
+            // Require that the settler is different from the local oracle
+            vm.assume(MandateOutputs[i].settler != localOracle.toIdentifier());
+
             expectedProofPayload = abi.encodePacked(
                 expectedProofPayload,
                 MandateOutputs[i].chainId,
@@ -112,6 +115,9 @@ contract InputSettlerCompactTest is InputSettlerCompactTestBase {
         MandateOutput[] memory MandateOutputs = new MandateOutput[](orderFulfillmentDescriptionWithSolver.length);
         bytes32[] memory solvers = new bytes32[](orderFulfillmentDescriptionWithSolver.length);
         for (uint256 i; i < orderFulfillmentDescriptionWithSolver.length; ++i) {
+            // Require that the settler is different from the local oracle
+            vm.assume(orderFulfillmentDescriptionWithSolver[i].MandateOutput.settler != localOracle.toIdentifier());
+
             timestamps[i] = orderFulfillmentDescriptionWithSolver[i].timestamp;
             MandateOutputs[i] = orderFulfillmentDescriptionWithSolver[i].MandateOutput;
             solvers[i] = orderFulfillmentDescriptionWithSolver[i].solver;

--- a/test/integration/SettlerCompact.crosschain.t.sol
+++ b/test/integration/SettlerCompact.crosschain.t.sol
@@ -403,11 +403,16 @@ contract InputSettlerCompactTestCrossChain is Test {
             solverIdentifier, orderId, uint32(block.timestamp), outputs[0]
         );
 
+        bytes32[] memory orderIds = new bytes32[](1);
+        orderIds[0] = orderId;
+        bytes32[] memory outputHashes = new bytes32[](1);
+        outputHashes[0] = MandateOutputEncodingLib.getMandateOutputHashMemory(outputs[0]);
+
         bytes memory expectedMessageEmitted = this.encodeMessage(outputs[0].settler, payloads);
 
         vm.expectEmit();
         emit PackagePublished(0, expectedMessageEmitted, 15);
-        wormholeOracle.submit(address(outputSettlerCoin), payloads);
+        wormholeOracle.submit(address(outputSettlerCoin), payloads, orderIds, outputHashes);
         vm.snapshotGasLastCall("inputSettler", "IntegrationWormholeSubmit");
 
         bytes memory vaa =
@@ -502,11 +507,19 @@ contract InputSettlerCompactTestCrossChain is Test {
                 solverIdentifier2, orderId, uint32(block.timestamp), outputs[1]
             );
 
+            // Create required arrays for new submit interface
+            bytes32[] memory orderIds = new bytes32[](2);
+            orderIds[0] = orderId;
+            orderIds[1] = orderId;
+            bytes32[] memory outputHashes = new bytes32[](2);
+            outputHashes[0] = MandateOutputEncodingLib.getMandateOutputHashMemory(outputs[0]);
+            outputHashes[1] = MandateOutputEncodingLib.getMandateOutputHashMemory(outputs[1]);
+
             bytes memory expectedMessageEmitted = this.encodeMessage(outputs[0].settler, payloads);
 
             vm.expectEmit();
             emit PackagePublished(0, expectedMessageEmitted, 15);
-            wormholeOracle.submit(address(outputSettlerCoin), payloads);
+            wormholeOracle.submit(address(outputSettlerCoin), payloads, orderIds, outputHashes);
 
             bytes memory vaa =
                 makeValidVAA(uint16(block.chainid), address(wormholeOracle).toIdentifier(), expectedMessageEmitted);

--- a/test/oracle/wormhole/WormholeOracle.submit.t.sol
+++ b/test/oracle/wormhole/WormholeOracle.submit.t.sol
@@ -93,9 +93,14 @@ contract WormholeOracleTestSubmit is Test {
         bytes[] memory payloads = new bytes[](1);
         payloads[0] = payload;
 
+        bytes32[] memory orderIds = new bytes32[](1);
+        orderIds[0] = orderId;
+        bytes32[] memory outputHashes = new bytes32[](1);
+        outputHashes[0] = MandateOutputEncodingLib.getMandateOutputHashMemory(output);
+
         // Fill without submitting
         vm.expectRevert(abi.encodeWithSignature("NotAllPayloadsValid()"));
-        oracle.submit(address(filler), payloads);
+        oracle.submit(address(filler), payloads, orderIds, outputHashes);
 
         vm.expectCall(
             address(token),
@@ -109,25 +114,33 @@ contract WormholeOracleTestSubmit is Test {
 
         vm.expectEmit();
         emit PackagePublished(0, expectedPayload, 15);
-        oracle.submit(address(filler), payloads);
+        oracle.submit(address(filler), payloads, orderIds, outputHashes);
         vm.snapshotGasLastCall("oracle", "wormholeOracleSubmit");
     }
 
     function test_submit_excess_value(uint64 val, bytes[] calldata payloads) external {
         expectedValueOnCall = val;
-        oracle.submit{ value: val }(address(this), payloads);
+
+        // Empty values to satisfy the function signature
+        bytes32[] memory orderIds = new bytes32[](payloads.length);
+        bytes32[] memory outputHashes = new bytes32[](payloads.length);
+        oracle.submit{ value: val }(address(this), payloads, orderIds, outputHashes);
     }
 
     function test_revert_submit_excess_value(uint64 val, bytes[] calldata payloads) external {
         revertFallback = true;
         expectedValueOnCall = val;
 
+        // Empty values to satisfy the function signature
+        bytes32[] memory orderIds = new bytes32[](payloads.length);
+        bytes32[] memory outputHashes = new bytes32[](payloads.length);
+
         if (val > 0) vm.expectRevert();
-        oracle.submit{ value: val }(address(this), payloads);
+        oracle.submit{ value: val }(address(this), payloads, orderIds, outputHashes);
     }
 
     function arePayloadsValid(
-        bytes32[] calldata
+        bytes calldata
     ) external pure returns (bool) {
         return true;
     }

--- a/test/output/OutputSettlerCoin.fillOrderOutputs.t.sol
+++ b/test/output/OutputSettlerCoin.fillOrderOutputs.t.sol
@@ -4,12 +4,15 @@ pragma solidity ^0.8.22;
 import { Test } from "forge-std/Test.sol";
 
 import { MandateOutput } from "../../src/input/types/MandateOutputType.sol";
+
+import { IPayloadCreator } from "../../src/interfaces/IPayloadCreator.sol";
+import { MandateOutputEncodingLib } from "../../src/libs/MandateOutputEncodingLib.sol";
 import { OutputSettlerCoin } from "../../src/output/coin/OutputSettlerCoin.sol";
 
 import { MockERC20 } from "../mocks/MockERC20.sol";
 
 contract OutputSettlerCoinTestfillOrderOutputs is Test {
-    error FilledBySomeoneElse(bytes32 solver);
+    error AlreadyFilled(bytes32 orderId, bytes32 outputHash);
 
     event OutputFilled(bytes32 indexed orderId, bytes32 solver, uint32 timestamp, MandateOutput output);
 
@@ -32,7 +35,7 @@ contract OutputSettlerCoinTestfillOrderOutputs is Test {
 
     /// forge-config: default.isolate = true
     function test_fill_batch_gas() external {
-        test_fill_batch(
+        test_fill_batch_success(
             keccak256(bytes("orderId")),
             makeAddr("sender"),
             keccak256(bytes("filler")),
@@ -42,7 +45,7 @@ contract OutputSettlerCoinTestfillOrderOutputs is Test {
         );
     }
 
-    function test_fill_batch(
+    function test_fill_batch_success(
         bytes32 orderId,
         address sender,
         bytes32 filler,
@@ -95,32 +98,12 @@ contract OutputSettlerCoinTestfillOrderOutputs is Test {
             abi.encodeWithSignature("transferFrom(address,address,uint256)", sender, swapper, amount2)
         );
 
-        uint256 prefillSnapshot = vm.snapshot();
-
         vm.prank(sender);
         outputSettlerCoin.fillOrderOutputs(type(uint32).max, orderId, outputs, filler);
         vm.snapshotGasLastCall("outputSettler", "outputSettlerCoinfillOrderOutputs");
 
         assertEq(outputToken.balanceOf(swapper), uint256(amount) + uint256(amount2));
         assertEq(outputToken.balanceOf(sender), 0);
-
-        vm.revertTo(prefillSnapshot);
-        // Fill the first output by someone else. The other outputs won't be filled.
-        vm.prank(sender);
-        outputSettlerCoin.fill(type(uint32).max, orderId, outputs[0], nextFiller);
-
-        vm.expectRevert(abi.encodeWithSignature("FilledBySomeoneElse(bytes32)", (nextFiller)));
-        vm.prank(sender);
-        outputSettlerCoin.fillOrderOutputs(type(uint32).max, orderId, outputs, filler);
-
-        vm.revertTo(prefillSnapshot);
-        // Fill the second output by someone else. The first output will be filled.
-
-        vm.prank(sender);
-        outputSettlerCoin.fill(type(uint32).max, orderId, outputs[1], nextFiller);
-
-        vm.prank(sender);
-        outputSettlerCoin.fillOrderOutputs(type(uint32).max, orderId, outputs, filler);
     }
 
     function test_revert_fill_batch_fillDeadline(uint24 fillDeadline, uint24 excess) public {
@@ -151,5 +134,70 @@ contract OutputSettlerCoinTestfillOrderOutputs is Test {
         if (excess != 0) vm.expectRevert(abi.encodeWithSignature("FillDeadline()"));
         vm.prank(sender);
         outputSettlerCoin.fillOrderOutputs(fillDeadline, orderId, outputs, filler);
+    }
+
+    function test_fill_batch_revert_already_filled() public {
+        bytes32 orderId = keccak256(bytes("orderId"));
+        address sender = makeAddr("sender");
+        bytes32 filler = keccak256(bytes("filler"));
+        uint128 amount1 = 10 ** 18;
+        uint128 amount2 = 2 * 10 ** 18;
+        uint128 amount3 = 3 * 10 ** 18;
+        uint128 totalAmount = amount1 + amount2 + amount3;
+
+        outputToken.mint(sender, uint256(totalAmount));
+        vm.prank(sender);
+        outputToken.approve(outputSettlerCoinAddress, uint256(totalAmount));
+
+        // Create 3 outputs
+        MandateOutput[] memory outputs = new MandateOutput[](3);
+        outputs[0] = MandateOutput({
+            settler: bytes32(uint256(uint160(outputSettlerCoinAddress))),
+            oracle: bytes32(0),
+            chainId: block.chainid,
+            token: bytes32(uint256(uint160(outputTokenAddress))),
+            amount: amount1,
+            recipient: bytes32(uint256(uint160(swapper))),
+            call: bytes(""),
+            context: bytes("")
+        });
+
+        outputs[1] = MandateOutput({
+            settler: bytes32(uint256(uint160(outputSettlerCoinAddress))),
+            oracle: bytes32(0),
+            chainId: block.chainid,
+            token: bytes32(uint256(uint160(outputTokenAddress))),
+            amount: amount2,
+            recipient: bytes32(uint256(uint160(swapper))),
+            call: bytes(""),
+            context: bytes("")
+        });
+
+        outputs[2] = MandateOutput({
+            settler: bytes32(uint256(uint160(outputSettlerCoinAddress))),
+            oracle: bytes32(0),
+            chainId: block.chainid,
+            token: bytes32(uint256(uint160(outputTokenAddress))),
+            amount: amount3,
+            recipient: bytes32(uint256(uint160(swapper))),
+            call: bytes(""),
+            context: bytes("")
+        });
+
+        // Fill outputs[1] first
+        MandateOutput[] memory singleOutput = new MandateOutput[](1);
+        singleOutput[0] = outputs[1];
+
+        vm.prank(sender);
+        outputSettlerCoin.fillOrderOutputs(type(uint32).max, orderId, singleOutput, filler);
+
+        // Verify outputs[1] was filled
+        assertEq(outputToken.balanceOf(swapper), uint256(amount2));
+
+        // Now try to fill all 3 outputs together, should revert because outputs[1] is already filled
+        bytes32 outputHash = MandateOutputEncodingLib.getMandateOutputHashMemory(outputs[1]);
+        vm.expectRevert(abi.encodeWithSelector(AlreadyFilled.selector, orderId, outputHash));
+        vm.prank(sender);
+        outputSettlerCoin.fillOrderOutputs(type(uint32).max, orderId, outputs, filler);
     }
 }


### PR DESCRIPTION
## Problem  
`BaseOutputSettler` wrote **two** storage slots for every fill:  
1. `filledOutputs[orderId][outputHash] = solver`  
2. `_attestations[...] = true` so the settler could be queried as an oracle.  

This is unnecessary and we can save one `SSTORE` by merging the two. This does require that `BaseOutputSettler` does not inherit from `BaseSolver` anymore and has to implement `IOracle` itself.

## Proposed Solution  
Keep a single mapping that is simultaneously:  
• the *fill flag* **and**  
• the *oracle proof*.  

```solidity
_fillRecords[orderId][outputHash] = payloadHash;
```  

If the key is unset → not filled / not proven.  

Some other important changes:

- `arePayloadsValid` now needs the `orderId`, `outputHash` and `payloadHash` for every fill instead of just the `payloadHash` before. We still keep the interface generic and decode the input in the `BaseOutputSettler` implementation.
- Removed `isProven` from the `IOracle` interface since it was not needed by the protocol and specific implementations(i.e. `BaseOracle` can still expose it)
- `WormholeOracle.submit()` requires some additional parameters to build the payloads. I think this is acceptable, but I'm open if there's a better option.
- The input settler has to construct a different `proofSeries` when the oracle is a regular local oracle vs when it is the settler itself. This should work fine, but I'll admit it is a bit dirty. This is a result of the input settler being aware of the proof struct that the oracle expects. Another option is to have an intermediary contract that can translate the proofs, but unsure if that's any better/cleaner.

## Summary  
• Saving just one `SSTORE` per fill is a significant simplification and reduces gas cost by >20k as seen in the snapshots. It does introduce some overhead in other parts of the code(e.g. wormhole oracle submit), but the delta is much smaller, and arguably the function that needs to be the most optimal is the fill.

## TODO  
These are some pending tasks before we can consider this PR complete, but I wanted to get a first round of reviews before spending more time on it.
- [ ] Modify `InputSettler7683` to also support the output settler compact as an oracle
- [ ] Add tests for the new path in `InputSettlerCompact` when the output settler acts as an oracle