### PR TITLE
Disallow filling outputs twice

### DIFF
--- a/snapshots/inputSettler.json
+++ b/snapshots/inputSettler.json
@@ -10,10 +10,10 @@
   "CompactFinaliseFor": "139560",
   "CompactFinaliseSelf": "130980",
   "CompactFinaliseTo": "130980",
-  "IntegrationCoinFill": "112123",
+  "IntegrationCoinFill": "88713",
   "IntegrationCompactFinaliseSelf": "127613",
-  "IntegrationWormholeReceiveMessage": "73550",
-  "IntegrationWormholeSubmit": "42532",
+  "IntegrationWormholeReceiveMessage": "73514",
+  "IntegrationWormholeSubmit": "42505",
   "maxTimestamp1": "505",
   "minTimestamp1": "461"
 }

--- a/snapshots/oracle.json
+++ b/snapshots/oracle.json
@@ -1,9 +1,9 @@
 {
-  "bitcoinFinaliseDispute": "66591",
-  "bitcoinOPVerify": "87100",
-  "bitcoinOutputClaim": "99548",
-  "bitcoinOutputDispute": "74450",
-  "bitcoinVerify": "133931",
-  "bitcoinVerifyWithEmbed": "136556",
-  "wormholeOracleSubmit": "14084"
+  "bitcoinFinaliseDispute": "66580",
+  "bitcoinOPVerify": "87086",
+  "bitcoinOutputClaim": "99534",
+  "bitcoinOutputDispute": "74436",
+  "bitcoinVerify": "133921",
+  "bitcoinVerifyWithEmbed": "136546",
+  "wormholeOracleSubmit": "14057"
 }

--- a/snapshots/outputSettler.json
+++ b/snapshots/outputSettler.json
@@ -1,7 +1,7 @@
 {
-  "outputSettlerCoinFill": "105379",
-  "outputSettlerCoinFillDutchAuction": "107012",
-  "outputSettlerCoinFillExclusive": "107205",
-  "outputSettlerCoinFillExclusiveDutchAuction": "107952",
-  "outputSettlerCoinfillOrderOutputs": "164383"
+  "outputSettlerCoinFill": "81969",
+  "outputSettlerCoinFillDutchAuction": "83575",
+  "outputSettlerCoinFillExclusive": "83768",
+  "outputSettlerCoinFillExclusiveDutchAuction": "84497",
+  "outputSettlerCoinfillOrderOutputs": "117585"
 }

--- a/src/interfaces/IPayloadCreator.sol
+++ b/src/interfaces/IPayloadCreator.sol
@@ -6,6 +6,6 @@ pragma solidity >=0.8.0;
  */
 interface IPayloadCreator {
     function arePayloadsValid(
-        bytes32[] calldata payloads
+        bytes[] calldata payloads
     ) external view returns (bool);
 }

--- a/src/libs/MandateOutputEncodingLib.sol
+++ b/src/libs/MandateOutputEncodingLib.sol
@@ -107,6 +107,23 @@ library MandateOutputEncodingLib {
         return keccak256(encodeMandateOutputMemory(output));
     }
 
+    /**
+     * @notice Hash of an MandateOutput computed based on a fill description.
+     * @param oracle Address of the oracle of the output.
+     * @param settler Address of the settler contract of the output.
+     * @param chainId Identifier of the chain for the output.
+     * @param commonPayload Common payload of the serialised outputs.
+     * @return bytes32 OutputDescription hash.
+     */
+    function getMandateOutputHashFromCommonPayload(
+        bytes32 oracle,
+        bytes32 settler,
+        uint256 chainId,
+        bytes calldata commonPayload
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(oracle, settler, chainId, commonPayload));
+    }
+
     // --- FillDescription Encoding --- //
 
     /**
@@ -178,5 +195,47 @@ library MandateOutputEncodingLib {
             mandateOutput.call,
             mandateOutput.context
         );
+    }
+
+    // --- FillDescription Decoding --- //
+
+    /**
+     * @notice Loads the solver of the output from a serialised fill description.
+     * @param fillDescription Serialised fill description.
+     * @return solver Solver of the output.
+     */
+    function loadSolverFromFill(
+        bytes calldata fillDescription
+    ) internal pure returns (bytes32 solver) {
+        assembly ("memory-safe") {
+            solver := calldataload(fillDescription.offset)
+        }
+    }
+
+    /**
+     * @notice Loads the orderId from a serialised fill description.
+     * @param fillDescription Serialised fill description.
+     * @return orderId associated with the output.
+     */
+    function loadOrderIdFromFill(
+        bytes calldata fillDescription
+    ) internal pure returns (bytes32 orderId) {
+        assembly ("memory-safe") {
+            orderId := calldataload(add(fillDescription.offset, 0x20))
+        }
+    }
+
+    /**
+     * @notice Loads the timestamp when the fill was made from a serialised fill description.
+     * @param fillDescription Serialised fill description.
+     * @return ts Timestamp associated with the output.
+     */
+    function loadTimestampFromFill(
+        bytes calldata fillDescription
+    ) internal pure returns (uint32 ts) {
+        assembly ("memory-safe") {
+            // Clean the leftmost bytes: (32-4)*8 = 224
+            ts := shr(224, shl(224, calldataload(add(fillDescription.offset, 0x24))))
+        }
     }
 }

--- a/src/libs/OutputVerificationLib.sol
+++ b/src/libs/OutputVerificationLib.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.26;
 library OutputVerificationLib {
     error WrongChain(uint256 expected, uint256 actual);
     error WrongOutputSettler(bytes32 addressThis, bytes32 expected);
+    error WrongOutputOracle(bytes32 addressThis, bytes32 expected);
 
     /**
      * @param chainId Expected chain id. Validated to match block.chainId.
@@ -19,13 +20,24 @@ library OutputVerificationLib {
     }
 
     /**
-     * @notice Validate the remote oracle address is this contract.
+     * @notice Validate the remote settler address is this contract.
      */
     function _isThisOutputSettler(
         bytes32 outputSettler
     ) internal view {
         if (bytes32(uint256(uint160(address(this)))) != outputSettler) {
             revert WrongOutputSettler(bytes32(uint256(uint160(address(this)))), outputSettler);
+        }
+    }
+
+    /**
+     * @notice Validate the remote oracle address is this contract.
+     */
+    function _isThisOutputOracle(
+        bytes32 outputOracle
+    ) internal view {
+        if (bytes32(uint256(uint160(address(this)))) != outputOracle) {
+            revert WrongOutputOracle(bytes32(uint256(uint160(address(this)))), outputOracle);
         }
     }
 }

--- a/src/oracles/wormhole/WormholeOracle.sol
+++ b/src/oracles/wormhole/WormholeOracle.sol
@@ -41,12 +41,7 @@ contract WormholeOracle is ChainMap, BaseOracle, WormholeVerifier {
      * @return refund If too much value has been sent, the excess will be returned to msg.sender.
      */
     function submit(address source, bytes[] calldata payloads) public payable returns (uint256 refund) {
-        uint256 numPayloads = payloads.length;
-        bytes32[] memory payloadHashes = new bytes32[](numPayloads);
-        for (uint256 i; i < numPayloads; ++i) {
-            payloadHashes[i] = keccak256(payloads[i]);
-        }
-        if (!IPayloadCreator(source).arePayloadsValid(payloadHashes)) revert NotAllPayloadsValid();
+        if (!IPayloadCreator(source).arePayloadsValid(payloads)) revert NotAllPayloadsValid();
         return _submit(source, payloads);
     }
 

--- a/src/output/coin/OutputSettler7683.sol
+++ b/src/output/coin/OutputSettler7683.sol
@@ -25,7 +25,7 @@ contract OutputInputSettler7683 is BaseOutputSettler, IDestinationSettler {
     ) internal override returns (bytes32 recordedSolver) {
         uint256 amount = _getAmountMemory(output);
         recordedSolver = _fillMemory(orderId, output, amount, proposedSolver);
-        if (recordedSolver != proposedSolver) revert FilledBySomeoneElse(recordedSolver);
+        if (recordedSolver != proposedSolver) revert AlreadyFilled();
     }
 
     function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) external {
@@ -37,8 +37,8 @@ contract OutputInputSettler7683 is BaseOutputSettler, IDestinationSettler {
         MandateOutput memory output = abi.decode(originData, (MandateOutput));
 
         uint256 amount = _getAmountMemory(output);
-        bytes32 recordedSolver = _fillMemory(orderId, output, amount, proposedSolver);
-        if (recordedSolver != proposedSolver) revert FilledBySomeoneElse(recordedSolver);
+        bytes32 existingFillRecordHash = _fillMemory(orderId, output, amount, proposedSolver);
+        if (existingFillRecordHash != bytes32(0)) revert AlreadyFilled();
     }
 
     function _getAmountMemory(
@@ -56,48 +56,23 @@ contract OutputInputSettler7683 is BaseOutputSettler, IDestinationSettler {
         MandateOutput memory output,
         uint256 outputAmount,
         bytes32 proposedSolver
-    ) internal returns (bytes32) {
+    ) internal virtual returns (bytes32 existingFillRecordHash) {
         if (proposedSolver == bytes32(0)) revert ZeroValue();
-        // Validate order context. This lets us ensure that this filler is the correct filler for the output.
         OutputVerificationLib._isThisChain(output.chainId);
         OutputVerificationLib._isThisOutputSettler(output.settler);
 
-        // Get hash of output.
         bytes32 outputHash = MandateOutputEncodingLib.getMandateOutputHashMemory(output);
+        existingFillRecordHash = _fillRecords[orderId][outputHash];
+        if (existingFillRecordHash != bytes32(0)) return existingFillRecordHash; // Early return if already solved.
+        // The above and below lines act as a local re-entry check.
+        uint32 fillTimestamp = uint32(block.timestamp);
+        _fillRecords[orderId][outputHash] = _getFillRecordHash(proposedSolver, fillTimestamp);
 
-        // Get the proof state of the fulfillment.
-        bytes32 existingSolver = filledOutputs[orderId][outputHash];
-
-        // Early return if we have already seen proof.
-        if (existingSolver != bytes32(0)) return existingSolver;
-
-        // The fill status is set before the transfer.
-        // This allows the above code-chunk to act as a local re-entry check.
-        filledOutputs[orderId][outputHash] = proposedSolver;
-
-        // Set the associated attestation as true. This allows the filler to act as an oracle and check whether payload
-        // hashes have been filled. Note that within the payload we set the current timestamp. This
-        // timestamp needs to be collected from the event (or tx) to be able to reproduce the payload(hash)
-        bytes32 dataHash = keccak256(
-            MandateOutputEncodingLib.encodeFillDescriptionM(proposedSolver, orderId, uint32(block.timestamp), output)
-        );
-        _attestations[block.chainid][bytes32(uint256(uint160(address(this))))][bytes32(uint256(uint160(address(this))))][dataHash]
-        = true;
-
-        // Load order description.
+        // Storage has been set. Fill the output.
         address recipient = address(uint160(uint256(output.recipient)));
-        address token = address(uint160(uint256(output.token)));
+        SafeTransferLib.safeTransferFrom(address(uint160(uint256(output.token))), msg.sender, recipient, outputAmount);
+        if (output.call.length > 0) IOIFCallback(recipient).outputFilled(output.token, outputAmount, output.call);
 
-        // Collect tokens from the user. If this fails, then the call reverts and
-        // the proof is not set to true.
-        SafeTransferLib.safeTransferFrom(token, msg.sender, recipient, outputAmount);
-
-        // If there is an external call associated with the fill, execute it.
-        bytes memory remoteCall = output.call;
-        if (remoteCall.length > 0) IOIFCallback(recipient).outputFilled(output.token, outputAmount, remoteCall);
-
-        emit OutputFilled(orderId, proposedSolver, uint32(block.timestamp), output);
-
-        return proposedSolver;
+        emit OutputFilled(orderId, proposedSolver, fillTimestamp, output);
     }
 }

--- a/test/exploit/BitcoinOracle.OverwriteVerify.t.sol
+++ b/test/exploit/BitcoinOracle.OverwriteVerify.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+
+import { BtcPrism } from "bitcoinprism-evm/src/BtcPrism.sol";
+import { Endian } from "bitcoinprism-evm/src/Endian.sol";
+import { IBtcPrism } from "bitcoinprism-evm/src/interfaces/IBtcPrism.sol";
+import { BtcProof, BtcTxProof, ScriptMismatch } from "bitcoinprism-evm/src/library/BtcProof.sol";
+import { BtcScript } from "bitcoinprism-evm/src/library/BtcScript.sol";
+
+import { MandateOutput, MandateOutputEncodingLib } from "../../src/libs/MandateOutputEncodingLib.sol";
+import { BitcoinOracle } from "../../src/oracles/bitcoin/BitcoinOracle.sol";
+
+import { MockERC20 } from "../mocks/MockERC20.sol";
+import "../oracle/bitcoin/blocksinfo.t.sol";
+
+contract BitcoinOracleHarness is BitcoinOracle {
+    constructor(
+        address _lightClient,
+        address disputedOrderFeeDestination,
+        address collateralToken,
+        uint64 _collateralMultiplier
+    ) payable BitcoinOracle(_lightClient, disputedOrderFeeDestination, collateralToken, _collateralMultiplier) { }
+
+    function getProofPeriod(
+        uint256 confirmations
+    ) external pure returns (uint256) {
+        return _getProofPeriod(confirmations);
+    }
+}
+
+contract BitcoinOracleTest is Test {
+    uint32 maxTimeIncrement = 1 days - 1;
+
+    MockERC20 token;
+
+    BtcPrism btcPrism;
+    BitcoinOracleHarness bitcoinOracle;
+
+    uint256 multiplier = 1e10 * 100;
+
+    function setUp() public {
+        token = new MockERC20("Mock ERC20", "MOCK", 18);
+
+        btcPrism = new BtcPrism(BLOCK_HEIGHT, BLOCK_HASH, BLOCK_TIME, EXPECTED_TARGET, false);
+
+        bitcoinOracle = new BitcoinOracleHarness(address(btcPrism), address(0), address(token), uint64(multiplier));
+    }
+
+    function test_verify_dublicate_filler() public {
+        bytes32 orderId = keccak256("orderId");
+        address caller = makeAddr("solver");
+
+        // We need to warp to the Bitcoin block.
+        vm.warp(BLOCK_TIME);
+        bytes32 bitcoinOracleBytes32 = bytes32(uint256(uint160(address(bitcoinOracle))));
+        MandateOutput memory output = MandateOutput({
+            oracle: bytes32(uint256(uint160(address(this)))),
+            settler: bitcoinOracleBytes32,
+            token: bytes32(bytes.concat(hex"000000000000000000000000BC000000000000000000000000000000000000", UTXO_TYPE)),
+            recipient: bytes32(PHASH),
+            amount: SATS_AMOUNT,
+            chainId: uint32(block.chainid),
+            call: hex"",
+            context: hex""
+        });
+
+        uint256 collateralAmount = output.amount * multiplier;
+        token.mint(caller, collateralAmount * 2);
+        vm.prank(caller);
+        token.approve(address(bitcoinOracle), collateralAmount * 2);
+
+        bytes32 solver = keccak256("solver");
+        vm.prank(caller);
+        bitcoinOracle.claim(solver, orderId, output);
+
+        {
+            BtcTxProof memory inclusionProof = BtcTxProof({
+                blockHeader: BLOCK_HEADER,
+                txId: TX_ID,
+                txIndex: TX_INDEX,
+                txMerkleProof: TX_MERKLE_PROOF,
+                rawTx: RAW_TX
+            });
+
+            bitcoinOracle.verify(orderId, output, BLOCK_HEIGHT, inclusionProof, TX_OUTPUT_INDEX);
+        }
+        // Check if the payload has been correctly stored.
+        bytes memory payload =
+            MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = payload;
+        bool fillerValid = bitcoinOracle.arePayloadsValid(payloads);
+        assertEq(fillerValid, true);
+
+        // Try to overwrite the claim.
+        MandateOutput memory dublicateOutput = MandateOutput({
+            oracle: bytes32(uint256(uint160(address(this))) + 1),
+            settler: bitcoinOracleBytes32,
+            token: bytes32(bytes.concat(hex"000000000000000000000000BC000000000000000000000000000000000000", UTXO_TYPE)),
+            recipient: bytes32(PHASH),
+            amount: SATS_AMOUNT,
+            chainId: uint32(block.chainid),
+            call: hex"",
+            context: hex""
+        });
+        bytes32 dublicateSolver = keccak256("dublicateSolver");
+
+        vm.prank(caller);
+        bitcoinOracle.claim(dublicateSolver, orderId, dublicateOutput);
+
+        {
+            BtcTxProof memory inclusionProof = BtcTxProof({
+                blockHeader: BLOCK_HEADER,
+                txId: TX_ID,
+                txIndex: TX_INDEX,
+                txMerkleProof: TX_MERKLE_PROOF,
+                rawTx: RAW_TX
+            });
+
+            bitcoinOracle.verify(orderId, dublicateOutput, BLOCK_HEIGHT, inclusionProof, TX_OUTPUT_INDEX);
+        }
+
+        // Check if the payload has been correctly stored.
+        bytes memory dublicatePayload = MandateOutputEncodingLib.encodeFillDescriptionM(
+            dublicateSolver, orderId, uint32(BLOCK_TIME), dublicateOutput
+        );
+        bytes[] memory dublicatePayloads = new bytes[](1);
+        dublicatePayloads[0] = dublicatePayload;
+        bool dublicateFillerValid = bitcoinOracle.arePayloadsValid(dublicatePayloads);
+        assertEq(dublicateFillerValid, false);
+    }
+}

--- a/test/exploit/FillOutputsTwice.t.sol
+++ b/test/exploit/FillOutputsTwice.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import { Test } from "forge-std/Test.sol";
+
+import { MandateOutput } from "../../src/input/types/MandateOutputType.sol";
+import { MandateOutputEncodingLib } from "../../src/libs/MandateOutputEncodingLib.sol";
+import { OutputSettlerCoin } from "../../src/output/coin/OutputSettlerCoin.sol";
+
+import { MockCallbackExecutor } from "../mocks/MockCallbackExecutor.sol";
+import { MockERC20 } from "../mocks/MockERC20.sol";
+
+/**
+ * @notice The purse of this test is to ensure that outputs can't be filled twice.
+ */
+contract FillOutputsTwiceTest is Test {
+    OutputSettlerCoin outputSettlerCoin;
+
+    MockERC20 outputToken;
+    MockCallbackExecutor mockCallbackExecutor;
+
+    function setUp() public {
+        outputSettlerCoin = new OutputSettlerCoin();
+        outputToken = new MockERC20("TEST", "TEST", 18);
+    }
+
+    /// @dev This test specifically tests if we can ask whether an output has been filled.
+    function test_fill_different_oracles() external {
+        bytes32 orderId = bytes32(uint256(1));
+
+        uint256 amount = 10 ** 18;
+        address sender = makeAddr("sender");
+        outputToken.mint(sender, amount * 2);
+        vm.prank(sender);
+        outputToken.approve(address(outputSettlerCoin), amount * 2);
+
+        // This is the assumed "valid" output.
+        MandateOutput memory output = MandateOutput({
+            oracle: bytes32(uint256(uint160(address(this)))),
+            settler: bytes32(uint256(uint160(address(outputSettlerCoin)))),
+            token: bytes32(abi.encode(address(outputToken))),
+            amount: amount,
+            recipient: bytes32(abi.encode(makeAddr("recipient"))),
+            chainId: uint32(block.chainid),
+            call: hex"",
+            context: hex""
+        });
+
+        bytes32 solver = bytes32(uint256(uint160(sender)));
+
+        vm.prank(sender);
+        bytes32 fillRecord = outputSettlerCoin.fill(type(uint32).max, orderId, output, solver);
+        assertEq(fillRecord, bytes32(0));
+
+        // Validate that we can get the fill record:
+        bytes memory fillDescription =
+            MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(block.timestamp), output);
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = fillDescription;
+        bool outputValid = outputSettlerCoin.arePayloadsValid(payloads);
+        assertEq(outputValid, true);
+
+        // Fill the dublicate order with the intention to overwrite the solver.
+        // This is the assumed "invalid" output.
+        MandateOutput memory dublicateOutput = MandateOutput({
+            oracle: bytes32(uint256(uint160(address(this))) + 1),
+            settler: bytes32(uint256(uint160(address(outputSettlerCoin)))),
+            token: bytes32(abi.encode(address(outputToken))),
+            amount: amount,
+            recipient: bytes32(abi.encode(makeAddr("recipient"))),
+            chainId: uint32(block.chainid),
+            call: hex"",
+            context: hex""
+        });
+
+        bytes32 dublicateSolver = bytes32(uint256(123));
+        vm.prank(sender);
+        bytes32 dublicateFillRecord =
+            outputSettlerCoin.fill(type(uint32).max, orderId, dublicateOutput, dublicateSolver);
+        assertEq(dublicateFillRecord, bytes32(0));
+
+        bytes memory dublicateFillDescription = MandateOutputEncodingLib.encodeFillDescriptionM(
+            dublicateSolver, orderId, uint32(block.timestamp), dublicateOutput
+        );
+        // Check that these would end up filling the same MandateOutput
+        assertEq(this.getCommonPayload(fillDescription), this.getCommonPayload(dublicateFillDescription));
+
+        bytes[] memory dublicatePayloads = new bytes[](1);
+        dublicatePayloads[0] = dublicateFillDescription;
+        outputValid = outputSettlerCoin.arePayloadsValid(dublicatePayloads);
+        assertEq(outputValid, false); // Ensure that this is not claimed as valid.
+    }
+
+    function getCommonPayload(
+        bytes calldata fd
+    ) external returns (bytes calldata commonPayload) {
+        commonPayload = fd[68:];
+    }
+}

--- a/test/oracle/bitcoin/BitcoinOracle.t.sol
+++ b/test/oracle/bitcoin/BitcoinOracle.t.sol
@@ -847,10 +847,82 @@ contract BitcoinOracleTest is Test {
 
     /// forge-config: default.isolate = true
     function test_verify_gas() external {
-        test_verify(keccak256(bytes("solver")), keccak256(bytes("orderId")), makeAddr("caller"));
+        test_verify_as_filler(keccak256(bytes("solver")), keccak256(bytes("orderId")), makeAddr("caller"));
     }
 
-    function test_verify(bytes32 solver, bytes32 orderId, address caller) public {
+    function test_verify_as_filler(bytes32 solver, bytes32 orderId, address caller) public {
+        vm.assume(solver != bytes32(0));
+        vm.assume(orderId != bytes32(0));
+        vm.assume(caller != address(0));
+        vm.assume(caller != address(bitcoinOracle));
+
+        // We need to wrap to the Bitcoin block.
+        vm.warp(BLOCK_TIME);
+        bytes32 bitcoinOracleBytes32 = bytes32(uint256(uint160(address(bitcoinOracle))));
+        MandateOutput memory output = MandateOutput({
+            oracle: bytes32(uint256(uint160(address(this)))),
+            settler: bitcoinOracleBytes32,
+            token: bytes32(bytes.concat(hex"000000000000000000000000BC000000000000000000000000000000000000", UTXO_TYPE)),
+            recipient: bytes32(PHASH),
+            amount: SATS_AMOUNT,
+            chainId: uint32(block.chainid),
+            call: hex"",
+            context: hex""
+        });
+
+        uint256 collateralAmount = output.amount * multiplier;
+        token.mint(caller, collateralAmount);
+        vm.prank(caller);
+        token.approve(address(bitcoinOracle), collateralAmount);
+
+        vm.expectEmit();
+        emit OutputClaimed(orderId, bitcoinOracle.outputIdentifier(output));
+
+        vm.prank(caller);
+        bitcoinOracle.claim(solver, orderId, output);
+
+        // Check for a refund of collateral.
+        assertEq(token.balanceOf(address(bitcoinOracle)), collateralAmount);
+        assertEq(token.balanceOf(caller), 0);
+        {
+            BtcTxProof memory inclusionProof = BtcTxProof({
+                blockHeader: BLOCK_HEADER,
+                txId: TX_ID,
+                txIndex: TX_INDEX,
+                txMerkleProof: TX_MERKLE_PROOF,
+                rawTx: RAW_TX
+            });
+
+            bitcoinOracle.verify(orderId, output, BLOCK_HEIGHT, inclusionProof, TX_OUTPUT_INDEX);
+            vm.snapshotGasLastCall("oracle", "bitcoinVerify");
+        }
+        // Check if the payload has been correctly stored for both a local oracle and remote oracle.
+
+        // Remote oracle (as filler)
+        bytes memory payload =
+            MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = payload;
+        bool fillerValid = bitcoinOracle.arePayloadsValid(payloads);
+        assertEq(fillerValid, true);
+
+        // Check for a refund of collateral.
+        assertEq(token.balanceOf(caller), collateralAmount);
+        assertEq(token.balanceOf(address(bitcoinOracle)), 0);
+
+        // TODO: implement this check without stack too deep
+        // Check that storage has been correctly updated.
+        // (bytes32 solver_, uint32 claimTimestamp_, uint64 multiplier_, address sponsor_, address disputer_,) =
+        //     bitcoinOracle._claimedOrder(orderId, outputId);
+
+        // assertEq(bytes32(0), solver_);
+        // assertEq(0, claimTimestamp_);
+        // assertEq(0, uint256(multiplier_));
+        // assertEq(address(0), sponsor_);
+        // assertEq(address(0), disputer_);
+    }
+
+    function test_verify_as_oracle(bytes32 solver, bytes32 orderId, address caller) public {
         vm.assume(solver != bytes32(0));
         vm.assume(orderId != bytes32(0));
         vm.assume(caller != address(0));
@@ -896,18 +968,9 @@ contract BitcoinOracleTest is Test {
             bitcoinOracle.verify(orderId, output, BLOCK_HEIGHT, inclusionProof, TX_OUTPUT_INDEX);
             vm.snapshotGasLastCall("oracle", "bitcoinVerify");
         }
-        // Check if the payload has been correctly stored for both a local oracle and remote oracle.
-
-        // Remote oracle (as filler)
+        // Local oracle (as oracle)
         bytes memory payload =
             MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
-        bytes32[] memory payloadHashes = new bytes32[](1);
-        payloadHashes[0] = keccak256(payload);
-        bool fillerValid = bitcoinOracle.arePayloadsValid(payloadHashes);
-        assertEq(fillerValid, true);
-
-        // Local oracle (as oracle)
-
         bool oracleValid =
             bitcoinOracle.isProven(block.chainid, bitcoinOracleBytes32, bitcoinOracleBytes32, keccak256(payload));
         assertEq(oracleValid, true);
@@ -928,7 +991,75 @@ contract BitcoinOracleTest is Test {
         // assertEq(address(0), disputer_);
     }
 
-    function test_verify_custom_multiplier(
+    function test_verify_custom_multiplier_as_filler(
+        bytes32 solver,
+        bytes32 orderId,
+        address caller,
+        uint8 custom_multiplier
+    ) external {
+        vm.assume(custom_multiplier != 0);
+        vm.assume(solver != bytes32(0));
+        vm.assume(orderId != bytes32(0));
+        vm.assume(caller != address(0));
+        vm.assume(caller != address(bitcoinOracle));
+
+        // We need to wrap to the Bitcoin block.
+        vm.warp(BLOCK_TIME);
+        bytes32 bitcoinOracleBytes32 = bytes32(uint256(uint160(address(bitcoinOracle))));
+        MandateOutput memory output = MandateOutput({
+            oracle: bytes32(uint256(uint160(address(this)))),
+            settler: bitcoinOracleBytes32,
+            token: bytes32(bytes.concat(hex"000000000000000000000000BC000000000000000000000000000000000000", UTXO_TYPE)),
+            recipient: bytes32(PHASH),
+            amount: SATS_AMOUNT,
+            chainId: uint32(block.chainid),
+            call: hex"",
+            context: bytes.concat(bytes1(0xB0), bytes32(uint256(custom_multiplier)))
+        });
+
+        uint256 collateralAmount = output.amount * uint256(custom_multiplier);
+        token.mint(caller, collateralAmount);
+        vm.prank(caller);
+        token.approve(address(bitcoinOracle), collateralAmount);
+
+        bytes32 outputId = bitcoinOracle.outputIdentifier(output);
+
+        vm.expectEmit();
+        emit OutputClaimed(orderId, bitcoinOracle.outputIdentifier(output));
+
+        vm.prank(caller);
+        bitcoinOracle.claim(solver, orderId, output);
+
+        (,, uint64 multiplier_,,,) = bitcoinOracle._claimedOrder(orderId, outputId);
+
+        assertEq(custom_multiplier, multiplier_);
+
+        // Check for a refund of collateral.
+        assertEq(token.balanceOf(address(bitcoinOracle)), collateralAmount);
+        assertEq(token.balanceOf(caller), 0);
+
+        BtcTxProof memory inclusionProof = BtcTxProof({
+            blockHeader: BLOCK_HEADER,
+            txId: TX_ID,
+            txIndex: TX_INDEX,
+            txMerkleProof: TX_MERKLE_PROOF,
+            rawTx: RAW_TX
+        });
+
+        bitcoinOracle.verify(orderId, output, BLOCK_HEIGHT, inclusionProof, TX_OUTPUT_INDEX);
+
+        // Check if the payload has been correctly stored for both a local oracle and remote oracle.
+
+        // Remote oracle (as filler)
+        bytes memory payload =
+            MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = payload;
+        bool fillerValid = bitcoinOracle.arePayloadsValid(payloads);
+        assertEq(fillerValid, true);
+    }
+
+    function test_verify_custom_multiplier_as_oracle(
         bytes32 solver,
         bytes32 orderId,
         address caller,
@@ -985,18 +1116,9 @@ contract BitcoinOracleTest is Test {
 
         bitcoinOracle.verify(orderId, output, BLOCK_HEIGHT, inclusionProof, TX_OUTPUT_INDEX);
 
-        // Check if the payload has been correctly stored for both a local oracle and remote oracle.
-
-        // Remote oracle (as filler)
+        // Local oracle (as oracle)
         bytes memory payload =
             MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
-        bytes32[] memory payloadHashes = new bytes32[](1);
-        payloadHashes[0] = keccak256(payload);
-        bool fillerValid = bitcoinOracle.arePayloadsValid(payloadHashes);
-        assertEq(fillerValid, true);
-
-        // Local oracle (as oracle)
-
         bool oracleValid =
             bitcoinOracle.isProven(block.chainid, bitcoinOracleBytes32, bitcoinOracleBytes32, keccak256(payload));
         assertEq(oracleValid, true);
@@ -1087,10 +1209,65 @@ contract BitcoinOracleTest is Test {
 
     /// forge-config: default.isolate = true
     function test_verify_embed_gas() external {
-        test_verify_embed(keccak256(bytes("solver")), keccak256(bytes("orderId")), makeAddr("caller"));
+        test_verify_embed_as_filler(keccak256(bytes("solver")), keccak256(bytes("orderId")), makeAddr("caller"));
     }
 
-    function test_verify_embed(bytes32 solver, bytes32 orderId, address caller) public {
+    function test_verify_embed_as_filler(bytes32 solver, bytes32 orderId, address caller) public {
+        vm.assume(solver != bytes32(0));
+        vm.assume(orderId != bytes32(0));
+        vm.assume(caller != address(0));
+        vm.assume(caller != address(bitcoinOracle));
+
+        // We need to wrap to the Bitcoin block.
+        vm.warp(BLOCK_TIME);
+        bytes32 bitcoinOracleBytes32 = bytes32(uint256(uint160(address(bitcoinOracle))));
+        MandateOutput memory output = MandateOutput({
+            oracle: bytes32(uint256(uint160(address(this)))),
+            settler: bitcoinOracleBytes32,
+            token: bytes32(
+                bytes.concat(hex"000000000000000000000000BC000000000000000000000000000000000000", EMBED_UTXO_TYPE)
+            ),
+            recipient: bytes32(EMBED_PHASH),
+            amount: EMBED_SATS_AMOUNT,
+            chainId: uint32(block.chainid),
+            call: EMBEDDED_DATA_RETURN,
+            context: hex""
+        });
+
+        uint256 collateralAmount = output.amount * multiplier;
+        token.mint(caller, collateralAmount);
+        vm.prank(caller);
+        token.approve(address(bitcoinOracle), collateralAmount);
+
+        vm.expectEmit();
+        emit OutputClaimed(orderId, bitcoinOracle.outputIdentifier(output));
+
+        vm.prank(caller);
+        bitcoinOracle.claim(solver, orderId, output);
+
+        BtcTxProof memory inclusionProof = BtcTxProof({
+            blockHeader: BLOCK_HEADER,
+            txId: EMBED_TX_ID,
+            txIndex: EMBED_TX_INDEX,
+            txMerkleProof: EMBED_TX_MERKLE_PROOF,
+            rawTx: EMBED_RAW_TX
+        });
+
+        bitcoinOracle.verify(orderId, output, BLOCK_HEIGHT, inclusionProof, EMBED_TX_OUTPUT_INDEX);
+        vm.snapshotGasLastCall("oracle", "bitcoinVerifyWithEmbed");
+
+        // Check if the payload has been correctly stored for both a local oracle and remote oracle.
+
+        // Remote oracle (as filler)
+        bytes memory payload =
+            MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = payload;
+        bool fillerValid = bitcoinOracle.arePayloadsValid(payloads);
+        assertEq(fillerValid, true);
+    }
+
+    function test_verify_embed_as_oracle(bytes32 solver, bytes32 orderId, address caller) public {
         vm.assume(solver != bytes32(0));
         vm.assume(orderId != bytes32(0));
         vm.assume(caller != address(0));
@@ -1134,18 +1311,9 @@ contract BitcoinOracleTest is Test {
         bitcoinOracle.verify(orderId, output, BLOCK_HEIGHT, inclusionProof, EMBED_TX_OUTPUT_INDEX);
         vm.snapshotGasLastCall("oracle", "bitcoinVerifyWithEmbed");
 
-        // Check if the payload has been correctly stored for both a local oracle and remote oracle.
-
-        // Remote oracle (as filler)
+        // Local oracle (as oracle)
         bytes memory payload =
             MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
-        bytes32[] memory payloadHashes = new bytes32[](1);
-        payloadHashes[0] = keccak256(payload);
-        bool fillerValid = bitcoinOracle.arePayloadsValid(payloadHashes);
-        assertEq(fillerValid, true);
-
-        // Local oracle (as oracle)
-
         bool oracleValid =
             bitcoinOracle.isProven(block.chainid, bitcoinOracleBytes32, bitcoinOracleBytes32, keccak256(payload));
         assertEq(oracleValid, true);
@@ -1262,7 +1430,7 @@ contract BitcoinOracleTest is Test {
         vm.warp(BLOCK_TIME);
         bytes32 bitcoinOracleBytes32 = bytes32(uint256(uint160(address(bitcoinOracle))));
         MandateOutput memory output = MandateOutput({
-            oracle: bitcoinOracleBytes32,
+            oracle: bytes32(uint256(uint160(address(this)))),
             settler: bitcoinOracleBytes32,
             token: bytes32(bytes.concat(hex"000000000000000000000000BC000000000000000000000000000000000000", UTXO_TYPE)),
             recipient: bytes32(PHASH),
@@ -1293,9 +1461,9 @@ contract BitcoinOracleTest is Test {
         // Remote oracle (as filler)
         bytes memory payload =
             MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(PREV_BLOCK_TIME), output);
-        bytes32[] memory payloadHashes = new bytes32[](1);
-        payloadHashes[0] = keccak256(payload);
-        bool fillerValid = bitcoinOracle.arePayloadsValid(payloadHashes);
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = payload;
+        bool fillerValid = bitcoinOracle.arePayloadsValid(payloads);
         assertEq(fillerValid, true);
     }
 
@@ -1360,7 +1528,7 @@ contract BitcoinOracleTest is Test {
         vm.warp(BLOCK_TIME);
         bytes32 bitcoinOracleBytes32 = bytes32(uint256(uint160(address(bitcoinOracle))));
         MandateOutput memory output = MandateOutput({
-            oracle: bitcoinOracleBytes32,
+            oracle: bytes32(uint256(uint160(address(this)))),
             settler: bitcoinOracleBytes32,
             token: bytes32(bytes.concat(hex"000000000000000000000000BC000000000000000000000000000000000000", UTXO_TYPE)),
             recipient: bytes32(PHASH),
@@ -1391,9 +1559,9 @@ contract BitcoinOracleTest is Test {
         // Remote oracle (as filler)
         bytes memory payload =
             MandateOutputEncodingLib.encodeFillDescriptionM(solver, orderId, uint32(BLOCK_TIME), output);
-        bytes32[] memory payloadHashes = new bytes32[](1);
-        payloadHashes[0] = keccak256(payload);
-        bool fillerValid = bitcoinOracle.arePayloadsValid(payloadHashes);
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = payload;
+        bool fillerValid = bitcoinOracle.arePayloadsValid(payloads);
         assertEq(fillerValid, true);
     }
 

--- a/test/oracle/wormhole/WormholeOracle.submit.t.sol
+++ b/test/oracle/wormhole/WormholeOracle.submit.t.sol
@@ -127,7 +127,7 @@ contract WormholeOracleTestSubmit is Test {
     }
 
     function arePayloadsValid(
-        bytes32[] calldata
+        bytes[] calldata
     ) external pure returns (bool) {
         return true;
     }

--- a/test/output/OutputSettlerCoin.fill.t.sol
+++ b/test/output/OutputSettlerCoin.fill.t.sol
@@ -504,8 +504,8 @@ contract OutputSettlerCoinTestFill is Test {
         vm.prank(sender);
         bytes32 alreadyFilledBy = outputSettlerCoin.fill(type(uint32).max, orderId, output, differentFiller);
 
-        assertNotEq(alreadyFilledBy, differentFiller);
-        assertEq(alreadyFilledBy, filler);
+        assertNotEq(alreadyFilledBy, keccak256(abi.encodePacked(differentFiller, uint32(block.timestamp))));
+        assertEq(alreadyFilledBy, keccak256(abi.encodePacked(filler, uint32(block.timestamp))));
     }
 
     function test_invalid_fulfillment_context(

--- a/test/output/OutputSettlerCoin.fillOrderOutputs.t.sol
+++ b/test/output/OutputSettlerCoin.fillOrderOutputs.t.sol
@@ -9,8 +9,6 @@ import { OutputSettlerCoin } from "../../src/output/coin/OutputSettlerCoin.sol";
 import { MockERC20 } from "../mocks/MockERC20.sol";
 
 contract OutputSettlerCoinTestfillOrderOutputs is Test {
-    error FilledBySomeoneElse(bytes32 solver);
-
     event OutputFilled(bytes32 indexed orderId, bytes32 solver, uint32 timestamp, MandateOutput output);
 
     OutputSettlerCoin outputSettlerCoin;
@@ -109,7 +107,7 @@ contract OutputSettlerCoinTestfillOrderOutputs is Test {
         vm.prank(sender);
         outputSettlerCoin.fill(type(uint32).max, orderId, outputs[0], nextFiller);
 
-        vm.expectRevert(abi.encodeWithSignature("FilledBySomeoneElse(bytes32)", (nextFiller)));
+        vm.expectRevert(abi.encodeWithSignature("AlreadyFilled()"));
         vm.prank(sender);
         outputSettlerCoin.fillOrderOutputs(type(uint32).max, orderId, outputs, filler);
 


### PR DESCRIPTION
The current implementation of the `BaseOutputSettler` and `BitcoinOracle` allows outputs to be filled with 2 different outputs – `output.oracle` is never properly read thus 2 outputs that only differ in `output.oracle` would be independently fillable but store the same fillAttestation.
In other words, a filled output maps fills in the dimension of the oracle but are filled in the dimension of the oracle.

**Core issue**
The core issue is that `_attestations(fillDescription)` does not contain the oracle AND `filledOutputs(output)` checks the oracle. This lets multiple orders set `_attestations(fillDescription)` for different solvers.

**Solution**
Storage is moved into a single map at _fillRecords(output) returning `keccak256(solver, timestamp)`. This allows for a similar but less precise check on fill. The valid payloads field now properly asserts the incoming package by assuming `msg.sender == output.oracle`.
`_attestations` are now set specifically when requested and with the appropriate oracle context.

On `BitcoinOracle` the expected oracle is now set in the attestation. Note, when `BitcoinOracle` is accessed directly the value of `output.oracle` is not checked AT ALL and any value will pass. Otherwise  `_isProven` should be overwritten with:

```solidity
function _isProven(
    uint256 remoteChainId,
    bytes32 remoteOracle,
    bytes32 application,
    bytes32 dataHash
) internal view virtual returns (bool) {
    require(remoteOracle == bytes32(uint256(uint160(address(this)))));
    return _attestations[remoteChainId][bytes32(uint256(uint160(address(this))))][application][dataHash];
}
``` 


The PR implements tests, see `test/exploits/BitcoinOracle.OverwriteVerify.t` and `test/exploits/FillOutputsTwice.t`. These fail on main, indicating an attack vector.