### PR TITLE
Do not delete solver of claimed order to avoid double claiming

### DIFF
--- a/snapshots/oracle.json
+++ b/snapshots/oracle.json
@@ -1,9 +1,9 @@
 {
-  "bitcoinFinaliseDispute": "66591",
-  "bitcoinOPVerify": "87100",
+  "bitcoinFinaliseDispute": "63838",
+  "bitcoinOPVerify": "88991",
   "bitcoinOutputClaim": "99548",
-  "bitcoinOutputDispute": "74450",
-  "bitcoinVerify": "133931",
-  "bitcoinVerifyWithEmbed": "136556",
+  "bitcoinOutputDispute": "72356",
+  "bitcoinVerify": "135814",
+  "bitcoinVerifyWithEmbed": "138439",
   "wormholeOracleSubmit": "14084"
 }

--- a/src/oracles/bitcoin/BitcoinOracle.sol
+++ b/src/oracles/bitcoin/BitcoinOracle.sol
@@ -56,10 +56,9 @@ contract BitcoinOracle is BaseOracle {
         bytes32 solver;
         uint32 claimTimestamp;
         uint64 multiplier;
-        address sponsor;
+        address claimant;
         address disputer;
-        /// @notice For a claim to be paid to the sponsor, it is required that the input was included before this
-        /// timestamp.
+        /// @notice For a claim to be paid to the claimant, the input has to be included before this timestamp.
         /// For disputers, note that it is possible to set the inclusion timestamp to 1 block prior.
         /// @dev Is the maximum of (block.timestamp and claimTimestamp + MIN_TIME_FOR_INCLUSION)
         uint32 disputeTimestamp;
@@ -518,21 +517,20 @@ contract BitcoinOracle is BaseOracle {
         solver = claimedOrder.solver;
         if (solver == bytes32(0)) revert NotClaimed();
 
-        address sponsor = claimedOrder.sponsor;
+        address claimant = claimedOrder.claimant;
         uint96 multiplier = claimedOrder.multiplier;
         uint32 disputeTimestamp = claimedOrder.disputeTimestamp;
         address disputer = claimedOrder.disputer;
 
         // - fillTimestamp >= claimTimestamp is not checked and it is assumed the 1 day validation window is sufficient
         // to check that the transaction was made to fill this output.
-        if (sponsor != address(0) && (disputer == address(0) || fillTimestamp <= disputeTimestamp)) {
+        if (claimant != address(0) && (disputer == address(0) || fillTimestamp <= disputeTimestamp)) {
             bool disputed = disputer != address(0);
 
             // Delete storage; no re-entry.
-            delete claimedOrder.solver;
             delete claimedOrder.multiplier;
             delete claimedOrder.claimTimestamp;
-            delete claimedOrder.sponsor;
+            delete claimedOrder.claimant;
             delete claimedOrder.disputer;
             delete claimedOrder.disputeTimestamp;
 
@@ -541,7 +539,7 @@ contract BitcoinOracle is BaseOracle {
             collateralAmount =
                 disputed ? collateralAmount * (CHALLENGER_COLLATERAL_FACTOR + 1) - disputeCost : collateralAmount;
 
-            SafeTransferLib.safeTransfer(COLLATERAL_TOKEN, sponsor, collateralAmount);
+            SafeTransferLib.safeTransfer(COLLATERAL_TOKEN, claimant, collateralAmount);
             if (disputed && 0 < disputeCost) {
                 SafeTransferLib.safeTransfer(COLLATERAL_TOKEN, DISPUTED_ORDER_FEE_DESTINATION, disputeCost);
             }
@@ -567,7 +565,7 @@ contract BitcoinOracle is BaseOracle {
 
         claimedOrder.solver = solver;
         claimedOrder.claimTimestamp = uint32(block.timestamp);
-        claimedOrder.sponsor = msg.sender;
+        claimedOrder.claimant = msg.sender;
         claimedOrder.multiplier = uint64(multiplier);
         // The above lines acts as a local re-entry guard. External calls are now allowed.
 
@@ -587,7 +585,7 @@ contract BitcoinOracle is BaseOracle {
 
         ClaimedOrder storage claimedOrder = _claimedOrder[orderId][outputId];
         if (claimedOrder.claimTimestamp + DISPUTE_PERIOD < block.timestamp) revert TooLate();
-        if (claimedOrder.solver == bytes32(0)) revert NotClaimed();
+        if (claimedOrder.claimant == address(0)) revert NotClaimed();
 
         if (claimedOrder.disputer != address(0)) revert AlreadyDisputed(claimedOrder.disputer);
         claimedOrder.disputer = msg.sender;
@@ -613,7 +611,7 @@ contract BitcoinOracle is BaseOracle {
         bytes32 outputId = _outputIdentifier(output);
 
         ClaimedOrder storage claimedOrder = _claimedOrder[orderId][outputId];
-        if (claimedOrder.solver == bytes32(0)) revert NotClaimed();
+        if (claimedOrder.claimant == address(0)) revert NotClaimed();
         if (claimedOrder.claimTimestamp + DISPUTE_PERIOD >= block.timestamp) revert TooEarly();
         bool disputed = claimedOrder.disputer != address(0);
         if (disputed) revert Disputed();
@@ -625,19 +623,18 @@ contract BitcoinOracle is BaseOracle {
         = true;
         emit OutputFilled(orderId, solver, uint32(block.timestamp), output);
 
-        address sponsor = claimedOrder.sponsor;
+        address claimant = claimedOrder.claimant;
         uint256 multiplier = claimedOrder.multiplier;
 
-        delete claimedOrder.solver;
         delete claimedOrder.multiplier;
         delete claimedOrder.claimTimestamp;
-        delete claimedOrder.sponsor;
+        delete claimedOrder.claimant;
         delete claimedOrder.disputer;
         delete claimedOrder.disputeTimestamp;
         // The above lines acts as a local re-entry guard. External calls are now allowed.
 
         uint256 collateralAmount = output.amount * multiplier;
-        SafeTransferLib.safeTransfer(COLLATERAL_TOKEN, sponsor, collateralAmount);
+        SafeTransferLib.safeTransfer(COLLATERAL_TOKEN, claimant, collateralAmount);
 
         emit OutputOptimisticallyVerified(orderId, _outputIdentifier(output));
     }
@@ -661,10 +658,9 @@ contract BitcoinOracle is BaseOracle {
 
         if (disputeTimestamp + proofPeriod >= block.timestamp) revert TooEarly();
 
-        delete claimedOrder.solver;
         delete claimedOrder.multiplier;
         delete claimedOrder.claimTimestamp;
-        delete claimedOrder.sponsor;
+        delete claimedOrder.claimant;
         delete claimedOrder.disputer;
         delete claimedOrder.disputeTimestamp;
         // The above lines acts as a local re-entry guard. External calls are now allowed.

--- a/test/oracle/bitcoin/BitcoinOracle.t.sol
+++ b/test/oracle/bitcoin/BitcoinOracle.t.sol
@@ -524,7 +524,7 @@ contract BitcoinOracleTest is Test {
             uint32 disputeTimestamp_
         ) = bitcoinOracle._claimedOrder(orderId, outputId);
 
-        assertEq(bytes32(0), solver_);
+        assertEq(solver, solver_);
         assertEq(0, claimTimestamp_);
         assertEq(0, uint256(multiplier_));
         assertEq(address(0), sponsor_);
@@ -741,7 +741,7 @@ contract BitcoinOracleTest is Test {
         (solver_, claimTimestamp_, multiplier_, sponsor_, disputer_, disputeTimestamp_) =
             bitcoinOracle._claimedOrder(orderId, outputId);
 
-        assertEq(bytes32(0), solver_);
+        assertEq(solver, solver_);
         assertEq(0, claimTimestamp_);
         assertEq(0, uint256(multiplier_));
         assertEq(address(0), sponsor_);
@@ -926,6 +926,10 @@ contract BitcoinOracleTest is Test {
         // assertEq(0, uint256(multiplier_));
         // assertEq(address(0), sponsor_);
         // assertEq(address(0), disputer_);
+
+        // Try to claim the transaction again.
+        vm.expectRevert(abi.encodeWithSignature("AlreadyClaimed(bytes32)", solver));
+        bitcoinOracle.claim(keccak256(abi.encodePacked(solver)), orderId, output);
     }
 
     function test_verify_custom_multiplier(


### PR DESCRIPTION
Currently, it is possible to claim Bitcoin fills twice. This is an issue since the sequential claim (when verified) will set another fillDescription as true. This results in a race condition for finalising the order and claiming the inputs.

The solution implemented is to not delete `.solver` and change checks to be of `.claimant` on optimistic flows (renamed from `.sponsor`).