### PR TITLE
Improve naming of message decoding function

### DIFF
--- a/src/libs/MessageEncodingLib.sol
+++ b/src/libs/MessageEncodingLib.sol
@@ -51,7 +51,7 @@ library MessageEncodingLib {
      * @return application Source of the messages on the payload.
      * @return payloadHashes A hash of every payload.
      */
-    function decodeMessage(
+    function getHashesOfEncodedPayloads(
         bytes calldata encodedPayload
     ) internal pure returns (bytes32 application, bytes32[] memory payloadHashes) {
         unchecked {

--- a/src/oracles/wormhole/WormholeOracle.sol
+++ b/src/oracles/wormhole/WormholeOracle.sol
@@ -80,7 +80,7 @@ contract WormholeOracle is ChainMap, BaseOracle, WormholeVerifier {
     ) external {
         (uint16 remoteMessagingProtocolChainIdentifier, bytes32 remoteSenderIdentifier, bytes calldata message) =
             _verifyPacket(rawMessage);
-        (bytes32 application, bytes32[] memory payloadHashes) = MessageEncodingLib.decodeMessage(message);
+        (bytes32 application, bytes32[] memory payloadHashes) = MessageEncodingLib.getHashesOfEncodedPayloads(message);
 
         uint256 remoteChainId = _getMappedChainId(uint256(remoteMessagingProtocolChainIdentifier));
 

--- a/test/libs/MessageEncodingLib.t.sol
+++ b/test/libs/MessageEncodingLib.t.sol
@@ -16,7 +16,7 @@ contract MessageEncodingLibTest is Test {
     function decodeMemoryToCalldata(
         bytes calldata encodedPayloads
     ) external pure returns (bytes32 decodedApplication, bytes32[] memory decodedPayloadHashes) {
-        return MessageEncodingLib.decodeMessage(encodedPayloads);
+        return MessageEncodingLib.getHashesOfEncodedPayloads(encodedPayloads);
     }
 
     /// forge-config: default.block_gas_limit = 100000000000


### PR DESCRIPTION
_The function  encodeMessage() and  decodeMessage() are not symmetric although their function names seem to suggest this. This could be confusing to readers and maintainers of the code._

Changes the name of `MessageEncodingLib.decodeMessage` to `MessageEncodingLib.getHashesOfEncodedPayloads`