### PR TITLE
Fix stale finalise natspec comment

### DIFF
--- a/src/input/compact/InputSettlerCompact.sol
+++ b/src/input/compact/InputSettlerCompact.sol
@@ -168,8 +168,7 @@ contract InputSettlerCompact is BaseInputSettler, IInputSettlerCompact {
      * @param signatures A signature for the sponsor and the allocator. abi.encode(bytes(sponsorSignature),
      * bytes(allocatorData))
      * @param timestamps Array of timestamps when each output was filled
-     * @param solvers Array of solvers who filled each output (in order). For single solver, pass an array with only one
-     * element
+     * @param solvers Array of solvers who filled each output (in order of outputs).
      * @param destination Where to send the inputs. If the solver wants to send the inputs to themselves, they should
      * pass their address to this parameter.
      * @param call Optional callback data. If non-empty, will call orderFinalised on the destination
@@ -204,7 +203,7 @@ contract InputSettlerCompact is BaseInputSettler, IInputSettlerCompact {
      * @param signatures A signature for the sponsor and the allocator. abi.encode(bytes(sponsorSignature),
      * bytes(allocatorData))
      * @param timestamps Array of timestamps when each output was filled
-     * @param solvers Array of solvers who filled each output (in order). For single solver, pass an array with only
+     * @param solvers Array of solvers who filled each output (in order of outputs)
      * element
      * @param destination Where to send the inputs
      * @param call Optional callback data. If non-empty, will call orderFinalised on the destination


### PR DESCRIPTION
Previously, you could submit single solvers instead of an array to finalise. This is no longer allowed. Remove comment that describes this as a possibility.