### PR TITLE
Optimise output hash

### DIFF
--- a/src/input/types/MandateOutputType.sol
+++ b/src/input/types/MandateOutputType.sol
@@ -55,11 +55,14 @@ library MandateOutputType {
     ) internal pure returns (bytes32) {
         unchecked {
             bytes memory currentHash = new bytes(32 * outputs.length);
-
+            uint256 p;
+            assembly ("memory-safe") {
+                p := add(currentHash, 0x20)
+            }
             for (uint256 i = 0; i < outputs.length; ++i) {
                 bytes32 outputHash = hashOutput(outputs[i]);
                 assembly {
-                    mstore(add(add(currentHash, 0x20), mul(i, 0x20)), outputHash)
+                    mstore(add(p, mul(i, 0x20)), outputHash)
                 }
             }
             return keccak256(currentHash);
@@ -90,11 +93,14 @@ library MandateOutputType {
     ) internal pure returns (bytes32) {
         unchecked {
             bytes memory currentHash = new bytes(32 * outputs.length);
-
+            uint256 p;
+            assembly ("memory-safe") {
+                p := add(currentHash, 0x20)
+            }
             for (uint256 i = 0; i < outputs.length; ++i) {
                 bytes32 outputHash = hashOutputM(outputs[i]);
                 assembly {
-                    mstore(add(add(currentHash, 0x20), mul(i, 0x20)), outputHash)
+                    mstore(add(p, mul(i, 0x20)), outputHash)
                 }
             }
             return keccak256(currentHash);


### PR DESCRIPTION
When computing the output hash, a value is computed for each iteration in the for loop. This PR stores that value outside the for loop.