### PR TITLE
Assembly And Library

### DIFF
--- a/src/libs/AssemblyLib.sol
+++ b/src/libs/AssemblyLib.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+/// @notice Library for common assembly operations.
+library AssemblyLib {
+    /**
+     * @notice Computes `and(a, b)` in assembly.
+     * @dev Does not clean parameters. If both a and b are dirty, c may also be dirty.
+     * @param a Left boolean.
+     * @param b Right boolean.
+     * @return c Whether a and B are both true
+     */
+    function and(bool a, bool b) internal pure returns (bool c) {
+        assembly ("memory-safe") {
+            c := and(a, b)
+        }
+    }
+}

--- a/src/oracles/BaseOracle.sol
+++ b/src/oracles/BaseOracle.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.26;
 
 import { IOracle } from "../interfaces/IOracle.sol";
+import { AssemblyLib } from "../libs/AssemblyLib.sol";
 
 /**
  * @notice Base implementation for storing and exposting attesations for consumers. Maintains a storage slot which is
@@ -97,10 +98,7 @@ abstract contract BaseOracle is IOracle {
                     dataHash := calldataload(offset)
                     offset := add(offset, 0x20)
                 }
-                bool _proven = _isProven(remoteChainId, remoteOracle, application, dataHash);
-                assembly ("memory-safe") {
-                    state := and(state, _proven)
-                }
+                state = AssemblyLib.and(state, _isProven(remoteChainId, remoteOracle, application, dataHash));
             }
             if (!state) revert NotProven();
         }

--- a/src/oracles/bitcoin/BitcoinOracle.sol
+++ b/src/oracles/bitcoin/BitcoinOracle.sol
@@ -9,6 +9,7 @@ import { AddressType, BitcoinAddress, BtcScript } from "bitcoinprism-evm/src/lib
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 
+import { AssemblyLib } from "../../libs/AssemblyLib.sol";
 import { LibAddress } from "../../libs/LibAddress.sol";
 import { MandateOutput, MandateOutputEncodingLib } from "../../libs/MandateOutputEncodingLib.sol";
 import { OutputVerificationLib } from "../../libs/OutputVerificationLib.sol";
@@ -305,10 +306,7 @@ contract BitcoinOracle is BaseOracle {
         accumulator = true;
         uint256 numPayloads = payloads.length;
         for (uint256 i; i < numPayloads; ++i) {
-            bool payloadValid = _isPayloadValid(payloads[i]);
-            assembly ("memory-safe") {
-                accumulator := and(accumulator, payloadValid)
-            }
+            accumulator = AssemblyLib.and(accumulator, _isPayloadValid(payloads[i]));
         }
     }
 

--- a/src/output/BaseOutputSettler.sol
+++ b/src/output/BaseOutputSettler.sol
@@ -6,6 +6,7 @@ import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IOIFCallback } from "../interfaces/IOIFCallback.sol";
 import { IPayloadCreator } from "../interfaces/IPayloadCreator.sol";
 
+import { AssemblyLib } from "../libs/AssemblyLib.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
 import { MandateOutput, MandateOutputEncodingLib } from "../libs/MandateOutputEncodingLib.sol";
 import { OutputVerificationLib } from "../libs/OutputVerificationLib.sol";
@@ -255,10 +256,7 @@ abstract contract BaseOutputSettler is IPayloadCreator, BaseOracle {
         uint256 numPayloads = payloads.length;
         accumulator = true;
         for (uint256 i; i < numPayloads; ++i) {
-            bool payloadValid = _isPayloadValid(payloads[i]);
-            assembly ("memory-safe") {
-                accumulator := and(accumulator, payloadValid)
-            }
+            accumulator = AssemblyLib.and(accumulator, _isPayloadValid(payloads[i]));
         }
     }
 


### PR DESCRIPTION
Within a lot of for loops, the failure state is checked at the end of the loop. These loops benefit from assembly `ands` to optimise for gas.

This means there is a lot of reused assembly code in various places of the code. This PR puts it into a single library that we can also use to abstract other assembly logic with.

This PR closes: https://github.com/openintentsframework/oif-contracts/issues/47