### PR TITLE
Fix inaccurate comments, outdated comments, and typos

### DIFF
--- a/src/input/InputSettlerBase.sol
+++ b/src/input/InputSettlerBase.sol
@@ -43,7 +43,7 @@ abstract contract InputSettlerBase is EIP712 {
 
     /**
      * @notice Checks that a timestamp has not expired.
-     * @param timestamp The timestamp to validate that it is not less than block.timestamp
+     * @param timestamp The timestamp to validate that it is at least equal to block.timestamp
      */
     function _validateTimestampHasNotPassed(
         uint32 timestamp
@@ -73,13 +73,13 @@ abstract contract InputSettlerBase is EIP712 {
 
     /**
      * @notice Validates that the rightmost 20 bytes are not 0.
-     * @param destination The timestamp to validate that it is not less than block.timestamp
+     * @param destination Destination of the funds
      */
     function _validateDestination(
         bytes32 destination
     ) internal pure {
         bool isZero;
-        // Check if the rigthmost 20 bytes are not all 0. That is a stronger check than the entire 32 bytes.
+        // Check if the rightmost 20 bytes are not all 0. That is a stronger check than the entire 32 bytes.
         assembly ("memory-safe") {
             isZero := iszero(shl(96, destination))
         }

--- a/src/input/InputSettlerPurchase.sol
+++ b/src/input/InputSettlerPurchase.sol
@@ -44,7 +44,9 @@ abstract contract InputSettlerPurchase is InputSettlerBase {
 
     /**
      * @notice Enforces that the caller is the order owner.
-     * @dev Only reads the rightmost 20 bytes to allow solvers to opt-in to Compact transfers instead of withdrawals.
+     * @dev Only reads the rightmost 20 bytes to verify the owner/purchaser. This allows implementations to use the
+     * leftmost 12 bytes to encode further withdrawal logic.
+     * For TheCompact, 12 zero bytes indicates a withdrawals instead of a transfer.
      * @param orderOwner The order owner. The leftmost 12 bytes are not read.
      */
     function _orderOwnerIsCaller(

--- a/src/input/escrow/InputSettlerEscrow.sol
+++ b/src/input/escrow/InputSettlerEscrow.sol
@@ -96,7 +96,7 @@ contract InputSettlerEscrow is InputSettlerPurchase, IInputSettlerEscrow {
 
     /**
      * @notice Opens an intent for `order.user`. `order.input` tokens are collected from msg.sender.
-     * @param order  bytes representing an encoded StandadrdOrder.
+     * @param order bytes representing an encoded StandardOrder, encoded via abi.encode().
      */
     function open(
         bytes calldata order
@@ -123,7 +123,7 @@ contract InputSettlerEscrow is InputSettlerPurchase, IInputSettlerEscrow {
 
     /**
      * @notice Collect input tokens directly from msg.sender.
-     * @param order bytes representing an encoded StandadrdOrder.
+     * @param order bytes representing an encoded StandardOrder, encoded via abi.encode().
      */
     function _open(
         bytes calldata order
@@ -140,15 +140,15 @@ contract InputSettlerEscrow is InputSettlerPurchase, IInputSettlerEscrow {
     }
 
     /**
-     * @notice Opens an intent for `order.user`. `order.input` tokens are collected from `sponsor` through either
-     * permit2 or ERC3009.
+     * @notice Opens an intent for `order.user`. `order.input` tokens are collected from `sponsor` through transferFrom,
+     * permit2 or ERC-3009.
      * @dev This function may make multiple sub-call calls either directly from this contract or from deeper inside the
      * call tree. To protect against reentry, the function uses the `orderStatus`. Local reentry (calling twice) is
      * protected through a checks-effect pattern while global reentry is enforced by not allowing existing the function
      * with `orderStatus` not set to `Deposited`
-     * @param order  bytes representing an encoded StandadrdOrder.
+     * @param order bytes representing an encoded StandardOrder, encoded via abi.encode().
      * @param sponsor Address to collect tokens from.
-     * @param signature Allowance signature from user with a signature type encoded as:
+     * @param signature Allowance signature from sponsor with a signature type encoded as:
      * - SIGNATURE_TYPE_PERMIT2:  b1:0x00 | bytes:signature
      * - SIGNATURE_TYPE_3009:     b1:0x01 | bytes:signature OR abi.encode(bytes[]:signatures)
      */
@@ -417,7 +417,7 @@ contract InputSettlerEscrow is InputSettlerPurchase, IInputSettlerEscrow {
 
     /**
      * @dev This function employs a local reentry guard: we check the order status and then we update it afterwards.
-     * This is an important check as it is indeed to process external ERC20 transfers.
+     * This is an important check as it is intended to process external ERC20 transfers.
      * @param newStatus specifies the new status to set the order to. Should never be OrderStatus.Deposited.
      */
     function _resolveLock(


### PR DESCRIPTION
## Description

Fix inaccurate comments, outdated comments, and typos

## Additional Notes

Audit finding: `Inaccurate comments`
