### PR TITLE
Only allow order purchases on the escrow for opened orders

### DIFF
--- a/src/input/escrow/InputSettlerEscrow.sol
+++ b/src/input/escrow/InputSettlerEscrow.sol
@@ -469,6 +469,10 @@ contract InputSettlerEscrow is InputSettlerPurchase, IInputSettlerEscrow {
         // Sanity check to ensure the user thinks they are buying the right order.
         if (computedOrderId != orderPurchase.orderId) revert OrderIdMismatch(orderPurchase.orderId, computedOrderId);
 
+        // Validate that the order has been opened.
+        OrderStatus status = orderStatus[computedOrderId];
+        if (status != OrderStatus.Deposited) revert InvalidOrderStatus();
+
         _purchaseOrder(
             orderPurchase, order.inputs, orderSolvedByIdentifier, purchaser, expiryTimestamp, solverSignature
         );


### PR DESCRIPTION
## Description

Only allow order purchases on the escrow for opened orders. This prevents orders from being purchased before they are even opened. With `InputSettlerEscrow` it is important that orders are opened before they are filled. If an order is purchased before opened, it should be assumed that the order has not been filled. In that case, anyone can easily circumvent the purchase.

## Additional Notes

Audit finding: `openForAndFinalise() doesn't use _purchaseGetOrderOwner()`. (Not on this repository)