### PR TITLE
Validate input chain for purchases

### DIFF
--- a/src/input/compact/InputSettlerCompact.sol
+++ b/src/input/compact/InputSettlerCompact.sol
@@ -249,6 +249,7 @@ contract InputSettlerCompact is InputSettlerPurchase, IInputSettlerCompact {
         uint256 expiryTimestamp,
         bytes calldata solverSignature
     ) external virtual {
+        _validateInputChain(order.originChainId);
         bytes32 computedOrderId = _orderIdentifier(order);
         // Sanity check to ensure the user thinks they are buying the right order.
         if (computedOrderId != orderPurchase.orderId) revert OrderIdMismatch(orderPurchase.orderId, computedOrderId);

--- a/src/input/escrow/InputSettlerEscrow.sol
+++ b/src/input/escrow/InputSettlerEscrow.sol
@@ -465,6 +465,7 @@ contract InputSettlerEscrow is InputSettlerPurchase, IInputSettlerEscrow {
         uint256 expiryTimestamp,
         bytes calldata solverSignature
     ) external virtual {
+        _validateInputChain(order.originChainId);
         bytes32 computedOrderId = order.orderIdentifier();
         // Sanity check to ensure the user thinks they are buying the right order.
         if (computedOrderId != orderPurchase.orderId) revert OrderIdMismatch(orderPurchase.orderId, computedOrderId);


### PR DESCRIPTION
## Description

Validate the input chain for purchases to ensure that no accidentally purchases are being made on the wrong chain.

## Additional Notes

Audit finding: _`purchaseOrder()` functions don't check `originChainId`_