### PR TITLE
Alphabetical order to witness hash

### DIFF
--- a/src/input/escrow/Permit2WitnessType.sol
+++ b/src/input/escrow/Permit2WitnessType.sol
@@ -25,9 +25,8 @@ library Permit2WitnessType {
         "Permit2Witness(uint32 expires,address inputOracle,uint256[2][] inputs,MandateOutput[] outputs)"
     );
 
-    // M comes earlier than P.
     bytes constant PERMIT2_WITNESS_TYPE = abi.encodePacked(
-        "Permit2Witness(uint32 expires,address inputOracle,MandateOutput[] outputs)MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
+        "MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)Permit2Witness(uint32 expires,address inputOracle,MandateOutput[] outputs)"
     );
 
     bytes32 constant PERMIT2_WITNESS_TYPE_HASH = keccak256(PERMIT2_WITNESS_TYPE);

--- a/test/input/escrow/InputSettlerEscrow.base.t.sol
+++ b/test/input/escrow/InputSettlerEscrow.base.t.sol
@@ -96,7 +96,7 @@ contract InputSettlerEscrowTestBase is Permit2Test {
             abi.encode(
                 keccak256(
                     bytes(
-                        "Permit2Witness(uint32 expires,address inputOracle,MandateOutput[] outputs)MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
+                        "MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)Permit2Witness(uint32 expires,address inputOracle,MandateOutput[] outputs)"
                     )
                 ),
                 order.expires,


### PR DESCRIPTION
## Description

Apply alphabetical order of the elements in the witness hash for input settler escrow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered type encoding structure, updating all related hash computations and verification logic.

* **Tests**
  * Updated test suite to reflect structural encoding changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->