### PR TITLE
add HyperlaneOracleMapped

### DIFF
--- a/snapshots/oracle.json
+++ b/snapshots/oracle.json
@@ -11,8 +11,8 @@
   "citreaOutputDispute": "77535",
   "citreaVerify": "170275",
   "citreaVerifyWithEmbed": "172782",
-  "hyperlaneOracleHandle": "27605",
-  "hyperlaneOracleSubmit": "44824",
-  "hyperlaneOracleSubmitCustomHook": "45003",
+  "hyperlaneOracleHandle": "27791",
+  "hyperlaneOracleSubmit": "44802",
+  "hyperlaneOracleSubmitCustomHook": "44981",
   "wormholeOracleSubmit": "19569"
 }

--- a/src/integrations/oracles/hyperlane/HyperlaneOracle.sol
+++ b/src/integrations/oracles/hyperlane/HyperlaneOracle.sol
@@ -36,6 +36,17 @@ contract HyperlaneOracle is BaseInputOracle, MailboxClient, IMessageRecipient {
     ) MailboxClient(mailbox, customHook, ism) { }
 
     /**
+     * @dev Return the chain id from the chain identifier.
+     * @param chainIdentifier The chain identifier.
+     * @return chainId The chain id.
+     */
+    function _getChainId(
+        uint256 chainIdentifier
+    ) internal view virtual returns (uint256 chainId) {
+        return chainIdentifier;
+    }
+
+    /**
      * @notice Handles incoming Hyperlane messages.
      * @param messageOrigin The domain from which the message originates.
      * @param messageSender The address of the sender on the origin domain. The oracle.
@@ -51,9 +62,10 @@ contract HyperlaneOracle is BaseInputOracle, MailboxClient, IMessageRecipient {
         uint256 numPayloads = payloadHashes.length;
         for (uint256 i; i < numPayloads; ++i) {
             bytes32 payloadHash = payloadHashes[i];
-            _attestations[messageOrigin][messageSender][application][payloadHash] = true;
+            uint256 remoteChainId = _getChainId(uint256(messageOrigin));
+            _attestations[remoteChainId][messageSender][application][payloadHash] = true;
 
-            emit OutputProven(messageOrigin, messageSender, application, payloadHash);
+            emit OutputProven(remoteChainId, messageSender, application, payloadHash);
         }
     }
 

--- a/src/integrations/oracles/hyperlane/HyperlaneOracleMapped.sol
+++ b/src/integrations/oracles/hyperlane/HyperlaneOracleMapped.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { ChainMap } from "../../../oracles/ChainMap.sol";
+import { HyperlaneOracle } from "./HyperlaneOracle.sol";
+
+/**
+ * @notice Hyperlane Oracle with mapped chainIds
+ */
+contract HyperlaneOracleMapped is ChainMap, HyperlaneOracle {
+    constructor(
+        address _owner,
+        address mailbox,
+        address customHook,
+        address ism
+    ) ChainMap(_owner) HyperlaneOracle(mailbox, customHook, ism) { }
+
+    function _getChainId(
+        uint256 chainIdentifier
+    ) internal view override returns (uint256 chainId) {
+        return _getMappedChainId(chainIdentifier);
+    }
+}

--- a/test/oracle/hyperlane/HyperlaneOracleMapped.t.sol
+++ b/test/oracle/hyperlane/HyperlaneOracleMapped.t.sol
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.22;
+
+import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { MandateOutput } from "../../../src/input/types/MandateOutputType.sol";
+import { LibAddress } from "../../../src/libs/LibAddress.sol";
+import { MandateOutputEncodingLib } from "../../../src/libs/MandateOutputEncodingLib.sol";
+import { MessageEncodingLib } from "../../../src/libs/MessageEncodingLib.sol";
+import { OutputSettlerSimple } from "../../../src/output/simple/OutputSettlerSimple.sol";
+import { MockERC20 } from "../../mocks/MockERC20.sol";
+
+import { HyperlaneOracle } from "../../../src/integrations/oracles/hyperlane/HyperlaneOracle.sol";
+import { HyperlaneOracleMapped } from "../../../src/integrations/oracles/hyperlane/HyperlaneOracleMapped.sol";
+import {
+    IPostDispatchHook
+} from "../../../src/integrations/oracles/hyperlane/external/hyperlane/interfaces/hooks/IPostDispatchHook.sol";
+import {
+    StandardHookMetadata
+} from "../../../src/integrations/oracles/hyperlane/external/hyperlane/libs/StandardHookMetadata.sol";
+
+event OutputProven(uint256 chainid, bytes32 remoteIdentifier, bytes32 application, bytes32 payloadHash);
+
+contract MailboxMock {
+    uint256 public dispatchCounter;
+
+    function localDomain() external pure returns (uint32) {
+        return uint32(1);
+    }
+
+    function dispatch(
+        uint32,
+        bytes32,
+        bytes calldata,
+        bytes calldata,
+        IPostDispatchHook
+    ) external payable returns (bytes32 messageId) {
+        dispatchCounter += 1;
+        return keccak256(abi.encode(dispatchCounter));
+    }
+
+    function quoteDispatch(
+        uint32,
+        bytes32,
+        bytes calldata,
+        bytes calldata,
+        IPostDispatchHook
+    ) external pure returns (uint256 fee) {
+        return 1e18;
+    }
+}
+
+contract HyperlaneOracleMappedTest is Test {
+    using LibAddress for address;
+
+    MailboxMock internal _mailbox;
+    HyperlaneOracleMapped internal _oracle;
+
+    OutputSettlerSimple _outputSettler;
+    MockERC20 _token;
+
+    uint256 internal _gasPaymentQuote = 1e18;
+    uint256 internal _gasLimit = 60000;
+    uint32 internal _destination = 1;
+    uint32 internal _originHyperlaneId = 2;
+    uint32 internal _originChainId = 3;
+    address internal _recipientOracle = makeAddr("vegeta");
+    address internal _owner = makeAddr("owner");
+
+    function setUp() public {
+        _outputSettler = new OutputSettlerSimple();
+        _token = new MockERC20("TEST", "TEST", 18);
+
+        _mailbox = new MailboxMock();
+        _oracle =
+            new HyperlaneOracleMapped(address(_owner), address(_mailbox), makeAddr("kakaroto"), makeAddr("karpincho"));
+    }
+
+    function _getMandatePayload(
+        address sender,
+        uint256 amount,
+        address recipient,
+        bytes32 orderId,
+        bytes32 solverIdentifier
+    ) internal returns (MandateOutput memory output, bytes memory payload) {
+        _token.mint(sender, amount);
+        vm.prank(sender);
+        _token.approve(address(_outputSettler), amount);
+
+        output = MandateOutput({
+            oracle: address(_oracle).toIdentifier(),
+            settler: address(_outputSettler).toIdentifier(),
+            chainId: block.chainid,
+            token: bytes32(abi.encode(address(_token))),
+            amount: amount,
+            recipient: bytes32(abi.encode(recipient)),
+            callbackData: bytes(""),
+            context: bytes("")
+        });
+
+        payload = MandateOutputEncodingLib.encodeFillDescriptionMemory(
+            solverIdentifier,
+            orderId,
+            uint32(block.timestamp),
+            bytes32(abi.encode(address(_token))),
+            amount,
+            bytes32(abi.encode(recipient)),
+            bytes(""),
+            bytes("")
+        );
+
+        return (output, payload);
+    }
+
+    function encodeMessageCalldata(
+        bytes32 identifier,
+        bytes[] calldata payloads
+    ) external pure returns (bytes memory) {
+        return MessageEncodingLib.encodeMessage(identifier, payloads);
+    }
+
+    function getHashesOfEncodedPayloads(
+        bytes calldata encodedMessage
+    ) external pure returns (bytes32 application, bytes32[] memory payloadHashes) {
+        (application, payloadHashes) = MessageEncodingLib.getHashesOfEncodedPayloads(encodedMessage);
+    }
+
+    function test_submit_NotAllPayloadsValid(
+        address sender,
+        uint256 amount,
+        address recipient,
+        bytes32 orderId,
+        bytes32 solverIdentifier
+    ) public {
+        vm.assume(solverIdentifier != bytes32(0) && sender != address(0) && recipient != address(0));
+
+        MandateOutput memory output;
+        bytes[] memory payloads = new bytes[](1);
+        (output, payloads[0]) = _getMandatePayload(sender, amount, recipient, orderId, solverIdentifier);
+
+        // Fill without submitting
+        vm.expectRevert(abi.encodeWithSignature("NotAllPayloadsValid()"));
+        _oracle.submit{ value: _gasPaymentQuote }(
+            _destination, _recipientOracle, _gasLimit, bytes("customMetadata"), address(_outputSettler), payloads
+        );
+    }
+
+    function test_fill_works_w() external {
+        test_submit_works(
+            makeAddr("sender"),
+            10 ** 18,
+            makeAddr("recipient"),
+            keccak256(bytes("orderId")),
+            keccak256(bytes("solverIdentifier"))
+        );
+    }
+
+    function test_submit_works(
+        address sender,
+        uint256 amount,
+        address recipient,
+        bytes32 orderId,
+        bytes32 solverIdentifier
+    ) public {
+        vm.assume(solverIdentifier != bytes32(0) && sender != address(0) && recipient != address(0));
+
+        MandateOutput memory output;
+        bytes[] memory payloads = new bytes[](1);
+        (output, payloads[0]) = _getMandatePayload(sender, amount, recipient, orderId, solverIdentifier);
+
+        vm.expectCall(
+            address(_token),
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", address(sender), recipient, amount)
+        );
+
+        bytes memory fillerData = abi.encodePacked(solverIdentifier);
+
+        vm.prank(sender);
+        _outputSettler.fill(orderId, output, type(uint48).max, fillerData);
+
+        bytes memory customMetadata = bytes("customMetadata");
+
+        vm.expectCall(
+            address(_mailbox),
+            abi.encodeWithSelector(
+                MailboxMock.dispatch.selector,
+                _destination,
+                _recipientOracle.toIdentifier(),
+                this.encodeMessageCalldata(address(_outputSettler).toIdentifier(), payloads),
+                StandardHookMetadata.formatMetadata(0, _gasLimit, address(this), customMetadata),
+                _oracle.hook()
+            )
+        );
+
+        _oracle.submit{ value: _gasPaymentQuote }(
+            _destination, _recipientOracle, _gasLimit, customMetadata, address(_outputSettler), payloads
+        );
+        vm.snapshotGasLastCall("oracle", "hyperlaneOracleSubmit");
+    }
+
+    function test_submit_customHook_works_w() external {
+        test_submit_customHook_works(
+            makeAddr("sender"),
+            10 ** 18,
+            makeAddr("recipient"),
+            keccak256(bytes("orderId")),
+            keccak256(bytes("solverIdentifier")),
+            makeAddr("customHook")
+        );
+    }
+
+    function test_submit_customHook_works(
+        address sender,
+        uint256 amount,
+        address recipient,
+        bytes32 orderId,
+        bytes32 solverIdentifier,
+        address customHook
+    ) public {
+        vm.assume(solverIdentifier != bytes32(0) && sender != address(0) && recipient != address(0));
+
+        MandateOutput memory output;
+        bytes[] memory payloads = new bytes[](1);
+        (output, payloads[0]) = _getMandatePayload(sender, amount, recipient, orderId, solverIdentifier);
+
+        vm.expectCall(
+            address(_token),
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", address(sender), recipient, amount)
+        );
+
+        bytes memory fillerData = abi.encodePacked(solverIdentifier);
+
+        vm.prank(sender);
+        _outputSettler.fill(orderId, output, type(uint48).max, fillerData);
+
+        bytes memory customMetadata = bytes("customMetadata");
+
+        vm.expectCall(
+            address(_mailbox),
+            abi.encodeWithSelector(
+                MailboxMock.dispatch.selector,
+                _destination,
+                _recipientOracle.toIdentifier(),
+                this.encodeMessageCalldata(address(_outputSettler).toIdentifier(), payloads),
+                StandardHookMetadata.formatMetadata(0, _gasLimit, address(this), customMetadata),
+                IPostDispatchHook(customHook)
+            )
+        );
+
+        _oracle.submit{ value: _gasPaymentQuote }(
+            _destination,
+            _recipientOracle,
+            _gasLimit,
+            customMetadata,
+            IPostDispatchHook(customHook),
+            address(_outputSettler),
+            payloads
+        );
+        vm.snapshotGasLastCall("oracle", "hyperlaneOracleSubmitCustomHook");
+    }
+
+    function test_handle_onlyMailbox(
+        address sender,
+        uint256 amount,
+        address recipient,
+        bytes32 orderId,
+        bytes32 solverIdentifier
+    ) external {
+        vm.assume(solverIdentifier != bytes32(0) && sender != address(0) && recipient != address(0));
+
+        MandateOutput memory output;
+        bytes[] memory payloads = new bytes[](1);
+        (output, payloads[0]) = _getMandatePayload(sender, amount, recipient, orderId, solverIdentifier);
+
+        bytes memory message = this.encodeMessageCalldata(address(_outputSettler).toIdentifier(), payloads);
+
+        vm.expectRevert(abi.encodeWithSignature("SenderNotMailbox()"));
+        _oracle.handle(_originHyperlaneId, makeAddr("messageSender").toIdentifier(), message);
+    }
+
+    function test_handle_works_w() external {
+        test_handle_works(
+            makeAddr("sender"),
+            10 ** 18,
+            makeAddr("recipient"),
+            keccak256(bytes("orderId")),
+            keccak256(bytes("solverIdentifier"))
+        );
+    }
+
+    function test_handle_works(
+        address sender,
+        uint256 amount,
+        address recipient,
+        bytes32 orderId,
+        bytes32 solverIdentifier
+    ) public {
+        vm.assume(solverIdentifier != bytes32(0) && sender != address(0) && recipient != address(0));
+
+        MandateOutput memory output;
+        bytes[] memory payloads = new bytes[](1);
+        (output, payloads[0]) = _getMandatePayload(sender, amount, recipient, orderId, solverIdentifier);
+
+        bytes memory message = this.encodeMessageCalldata(address(_outputSettler).toIdentifier(), payloads);
+
+        (bytes32 application, bytes32[] memory payloadHashes) = this.getHashesOfEncodedPayloads(message);
+
+        bytes32 messageSender = makeAddr("messageSender").toIdentifier();
+
+        vm.prank(_owner);
+        _oracle.setChainMap(_originHyperlaneId, _originChainId);
+
+        vm.expectEmit();
+        emit OutputProven(_originChainId, messageSender, application, payloadHashes[0]);
+
+        vm.prank(address(_mailbox));
+        _oracle.handle(_originHyperlaneId, messageSender, message);
+        vm.snapshotGasLastCall("oracle", "hyperlaneOracleHandle");
+
+        assertTrue(_oracle.isProven(_originChainId, messageSender, application, payloadHashes[0]));
+    }
+
+    function test_handle_reverts_With_zero_value(
+        address sender,
+        uint256 amount,
+        address recipient,
+        bytes32 orderId,
+        bytes32 solverIdentifier
+    ) public {
+        vm.assume(solverIdentifier != bytes32(0) && sender != address(0) && recipient != address(0));
+
+        MandateOutput memory output;
+        bytes[] memory payloads = new bytes[](1);
+        (output, payloads[0]) = _getMandatePayload(sender, amount, recipient, orderId, solverIdentifier);
+
+        bytes memory message = this.encodeMessageCalldata(address(_outputSettler).toIdentifier(), payloads);
+
+        (bytes32 application, bytes32[] memory payloadHashes) = this.getHashesOfEncodedPayloads(message);
+
+        bytes32 messageSender = makeAddr("messageSender").toIdentifier();
+
+        vm.expectRevert(abi.encodeWithSignature("ZeroValue()"));
+        vm.prank(address(_mailbox));
+        _oracle.handle(_originHyperlaneId, messageSender, message);
+    }
+
+    function test_quoteGasPayment_works() public {
+        bytes memory customMetadata = bytes("customMetadata");
+
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = bytes("some payload");
+
+        vm.expectCall(
+            address(_mailbox),
+            abi.encodeWithSelector(
+                MailboxMock.quoteDispatch.selector,
+                _destination,
+                _recipientOracle.toIdentifier(),
+                this.encodeMessageCalldata(address(_outputSettler).toIdentifier(), payloads),
+                StandardHookMetadata.formatMetadata(0, _gasLimit, address(this), customMetadata),
+                _oracle.hook()
+            )
+        );
+
+        _oracle.quoteGasPayment(
+            _destination, _recipientOracle, _gasLimit, customMetadata, address(_outputSettler), payloads
+        );
+    }
+
+    function test_quoteGasPayment_customHook_works() public {
+        bytes memory customMetadata = bytes("customMetadata");
+        IPostDispatchHook customHook = IPostDispatchHook(makeAddr("customHook"));
+
+        bytes[] memory payloads = new bytes[](1);
+        payloads[0] = bytes("some payload");
+
+        vm.expectCall(
+            address(_mailbox),
+            abi.encodeWithSelector(
+                MailboxMock.quoteDispatch.selector,
+                _destination,
+                _recipientOracle.toIdentifier(),
+                this.encodeMessageCalldata(address(_outputSettler).toIdentifier(), payloads),
+                StandardHookMetadata.formatMetadata(0, _gasLimit, address(this), customMetadata),
+                customHook
+            )
+        );
+
+        _oracle.quoteGasPayment(
+            _destination, _recipientOracle, _gasLimit, customMetadata, customHook, address(_outputSettler), payloads
+        );
+    }
+
+    receive() external payable { }
+}

--- a/test/oracle/hyperlane/HyperlaneOracleMapped.t.sol
+++ b/test/oracle/hyperlane/HyperlaneOracleMapped.t.sol
@@ -197,7 +197,6 @@ contract HyperlaneOracleMappedTest is Test {
         _oracle.submit{ value: _gasPaymentQuote }(
             _destination, _recipientOracle, _gasLimit, customMetadata, address(_outputSettler), payloads
         );
-        vm.snapshotGasLastCall("oracle", "hyperlaneOracleSubmit");
     }
 
     function test_submit_customHook_works_w() external {
@@ -258,7 +257,6 @@ contract HyperlaneOracleMappedTest is Test {
             address(_outputSettler),
             payloads
         );
-        vm.snapshotGasLastCall("oracle", "hyperlaneOracleSubmitCustomHook");
     }
 
     function test_handle_onlyMailbox(
@@ -317,7 +315,6 @@ contract HyperlaneOracleMappedTest is Test {
 
         vm.prank(address(_mailbox));
         _oracle.handle(_originHyperlaneId, messageSender, message);
-        vm.snapshotGasLastCall("oracle", "hyperlaneOracleHandle");
 
         assertTrue(_oracle.isProven(_originChainId, messageSender, application, payloadHashes[0]));
     }


### PR DESCRIPTION
## Description
This PR adds a mapped version of Hyperlane Oracle to allow for chains in which the hyperlane id is different than the actual chain id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mapped-chain Hyperlane oracle integration (enables chainId mapping for cross-chain messages).

* **Tests**
  * Added comprehensive test suite with mailbox simulation covering submit, dispatch, handle, gas quoting, and custom hook flows.

* **Chores**
  * Updated gas snapshot values for Hyperlane oracle operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->