### PR TITLE
Enforce minimum fillerData size in FillerDataLib

### DIFF
--- a/src/output/simple/FillerDataLib.sol
+++ b/src/output/simple/FillerDataLib.sol
@@ -12,6 +12,9 @@ pragma solidity ^0.8.26;
  * PROPOSED_SOLVER       0               (32 bytes)  - bytes32: proposed solver address
  */
 library FillerDataLib {
+    /// @dev fillerData is shorter than the required 32 bytes
+    error FillerDataTooShort();
+
     /**
      * @notice Loads the proposed solver from the filler data.
      * @param fillerData Serialised filler data.
@@ -20,6 +23,7 @@ library FillerDataLib {
     function solver(
         bytes calldata fillerData
     ) internal pure returns (bytes32 _solver) {
+        if (fillerData.length < 32) revert FillerDataTooShort();
         assembly ("memory-safe") {
             _solver := calldataload(fillerData.offset)
         }


### PR DESCRIPTION
Adds a bounds check to FillerDataLib.solver() that reverts with FillerDataTooShort if the provided fillerData is less than 32 bytes. Previously, the assembly calldataload would silently read out-of-bounds calldata, potentially returning garbage data for the proposed solver address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to reject operations when filler data is insufficient, enhancing contract safety and preventing potential downstream errors during data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->