### PR TITLE
Fix Permit2 witness type stub

### DIFF
--- a/src/input/escrow/Permit2WitnessType.sol
+++ b/src/input/escrow/Permit2WitnessType.sol
@@ -22,7 +22,7 @@ struct Permit2Witness {
  */
 library Permit2WitnessType {
     bytes constant PERMIT2_WITNESS_TYPE_STUB = abi.encodePacked(
-        "Permit2Witness(address user,uint32 expires,address inputOracle,uint256[2][] inputs,MandateOutput[] outputs)"
+        "Permit2Witness(address user,uint32 expires,address inputOracle,MandateOutput[] outputs)"
     );
 
     // M comes earlier than P.

--- a/src/input/escrow/Permit2WitnessType.sol
+++ b/src/input/escrow/Permit2WitnessType.sol
@@ -21,9 +21,8 @@ struct Permit2Witness {
  * TYPE: Is complete including sub-types.
  */
 library Permit2WitnessType {
-    bytes constant PERMIT2_WITNESS_TYPE_STUB = abi.encodePacked(
-        "Permit2Witness(address user,uint32 expires,address inputOracle,MandateOutput[] outputs)"
-    );
+    bytes constant PERMIT2_WITNESS_TYPE_STUB =
+        abi.encodePacked("Permit2Witness(address user,uint32 expires,address inputOracle,MandateOutput[] outputs)");
 
     // M comes earlier than P.
     bytes constant PERMIT2_WITNESS_TYPE = abi.encodePacked(


### PR DESCRIPTION
The PERMIT2_WITNESS_TYPE_STUB was incorrectly including uint256[2][] inputs as a field in the witness type string. This field does not exist in the Permit2Witness struct, so its inclusion would cause signature verification to fail. The stub now matches the actual struct definition.