### PR TITLE
docs: add HyperlaneOracle mainnet deployments + deploy script

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -74,3 +74,42 @@ OIF settler contracts are deployed at identical, predictable addresses on every 
 | Bokuto (Katana testnet) | [Bokuto Explorer](https://bokuto.katanascan.com/address/0x1CC9260E285C2C8AC8D2E7102F3978056Ec1d0a8)                   |
 | BSC Testnet             | [Binance Smart Chain Testnet Explorer](https://testnet.bscscan.com/address/0x1CC9260E285C2C8AC8D2E7102F3978056Ec1d0a8)|
 | Polygon Amoy testnet    | [Polygon Amoy Explorer](https://amoy.polygonscan.com/address/0x1CC9260E285C2C8AC8D2E7102F3978056Ec1d0a8)              |
+
+## HyperlaneOracle
+
+`HyperlaneOracle` is deployed per chain against that chain's Hyperlane **Mailbox**. New deployments use
+CREATE2 (`salt = 0`, matching the repo's deterministic-deploy convention); the existing **Ethereum and
+Katana** oracles in the table below are already live (deployed earlier via plain CREATE). In neither
+case is the address shared across chains: each oracle binds its local Mailbox in the constructor, so
+the CREATE2 deployments' init-code hash (and thus their address) differs per chain, while the
+plain-CREATE ones derive from the deployer + nonce. Each address is deterministic per chain.
+
+Each oracle is deployed with **`customHook = 0x0`** and **`ism = 0x0`** so it uses the Mailbox's
+**default hook and default ISM**. Passing a custom ISM/hook address that has no code on-chain
+breaks message verification — always use `0x0` unless a verified custom module is intended.
+
+The Hyperlane **domain** equals the canonical **chain ID** on every chain below, so the base
+`HyperlaneOracle` (identity chain-id) is used — `HyperlaneOracleMapped` is not required.
+
+```
+constructor(address mailbox, address customHook, address ism)   // customHook = ism = 0x0
+```
+
+### Mainnets
+
+| Chain | Chain ID | Domain | Mailbox | IGP | HyperlaneOracle |
+| ----- | -------- | ------ | ------- | --- | --------------- |
+| Ethereum | 1 | 1 | [0xc005dc82818d67AF737725bD4bf75435d065D239](https://etherscan.io/address/0xc005dc82818d67AF737725bD4bf75435d065D239) | [0x9e6B1022bE9BBF5aFd152483DAD9b88911bC8611](https://etherscan.io/address/0x9e6B1022bE9BBF5aFd152483DAD9b88911bC8611) | [0x457b2241EFD4D57e9eaF9Eb72159128acF2aCDcc](https://etherscan.io/address/0x457b2241EFD4D57e9eaF9Eb72159128acF2aCDcc) |
+| Arbitrum One | 42161 | 42161 | [0x979Ca5202784112f4738403dBec5D0F3B9daabB9](https://arbiscan.io/address/0x979Ca5202784112f4738403dBec5D0F3B9daabB9) | [0x3b6044acd6767f017e99318AA6Ef93b7B06A5a22](https://arbiscan.io/address/0x3b6044acd6767f017e99318AA6Ef93b7B06A5a22) | [0x2A2A7570354787A6D5D797b43EE5f5c1f6a0f163](https://arbiscan.io/address/0x2A2A7570354787A6D5D797b43EE5f5c1f6a0f163) |
+| Base | 8453 | 8453 | [0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D](https://basescan.org/address/0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D) | [0xc3F23848Ed2e04C0c6d41bd7804fa8f89F940B94](https://basescan.org/address/0xc3F23848Ed2e04C0c6d41bd7804fa8f89F940B94) | [0x24d39b2807c6B50882fB6B9a4B4Dc6D36bbb297d](https://basescan.org/address/0x24d39b2807c6B50882fB6B9a4B4Dc6D36bbb297d) |
+| Optimism | 10 | 10 | [0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D](https://optimistic.etherscan.io/address/0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D) | [0xD8A76C4D91fCbB7Cc8eA795DFDF870E48368995C](https://optimistic.etherscan.io/address/0xD8A76C4D91fCbB7Cc8eA795DFDF870E48368995C) | [0xA7FA2Ca6b2Fe724Ad821340D95816f3e7e0f4b33](https://optimistic.etherscan.io/address/0xA7FA2Ca6b2Fe724Ad821340D95816f3e7e0f4b33) |
+| Linea | 59144 | 59144 | [0x02d16BC51af6BfD153d67CA61754cF912E82C4d9](https://lineascan.build/address/0x02d16BC51af6BfD153d67CA61754cF912E82C4d9) | [0x8105a095368f1a184CceA86cCe21318B5Ee5BE28](https://lineascan.build/address/0x8105a095368f1a184CceA86cCe21318B5Ee5BE28) | [0xFB99b2Ad53FA004f0D34d272E8A047af70082510](https://lineascan.build/address/0xFB99b2Ad53FA004f0D34d272E8A047af70082510) |
+| Scroll | 534352 | 534352 | [0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7](https://scrollscan.com/address/0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7) | [0xBF12ef4B9f307463D3FB59c3604F294dDCe287E2](https://scrollscan.com/address/0xBF12ef4B9f307463D3FB59c3604F294dDCe287E2) | [0xB2039f6B32eA8E19ab1D77E811EE7Cc5897BbDE3](https://scrollscan.com/address/0xB2039f6B32eA8E19ab1D77E811EE7Cc5897BbDE3) |
+| ZkSync Era | 324 | 324 | [0x6bD0A2214797Bc81e0b006F7B74d6221BcD8cb6E](https://era.zksync.network/address/0x6bD0A2214797Bc81e0b006F7B74d6221BcD8cb6E) | [0xf44AdA86a1f765A938d404699B8070Dd47bD2431](https://era.zksync.network/address/0xf44AdA86a1f765A938d404699B8070Dd47bD2431) | _pending deploy_ |
+| Katana | 747474 | 747474 | [0x3a464f746D23Ab22155710f44dB16dcA53e0775E](https://explorer.katanarpc.com/address/0x3a464f746D23Ab22155710f44dB16dcA53e0775E) | [0x23cc88CF424d48fDB05b4f0A8Ff6099aa4D56D8e](https://explorer.katanarpc.com/address/0x23cc88CF424d48fDB05b4f0A8Ff6099aa4D56D8e) | [0xc09cE4049dF4670A5A5804a17A310C5263a82aE3](https://explorer.katanarpc.com/address/0xc09cE4049dF4670A5A5804a17A310C5263a82aE3) |
+| BSC | 56 | 56 | [0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4](https://bscscan.com/address/0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4) | [0x78E25e7f84416e69b9339B0A6336EB6EFfF6b451](https://bscscan.com/address/0x78E25e7f84416e69b9339B0A6336EB6EFfF6b451) | [0x6Fc567D03eF10a05984717dB88F1baB7b1C95E23](https://bscscan.com/address/0x6Fc567D03eF10a05984717dB88F1baB7b1C95E23) |
+| Polygon | 137 | 137 | [0x5d934f4e2f797775e53561bB72aca21ba36B96BB](https://polygonscan.com/address/0x5d934f4e2f797775e53561bB72aca21ba36B96BB) | [0x0071740Bf129b05C4684abfbBeD248D80971cce2](https://polygonscan.com/address/0x0071740Bf129b05C4684abfbBeD248D80971cce2) | [0x50dc7199fEaab9a64F04da8aD56E6f123f8b3eB0](https://polygonscan.com/address/0x50dc7199fEaab9a64F04da8aD56E6f123f8b3eB0) |
+
+> **Note (ZkSync Era):** ZK Stack uses non-standard CREATE/CREATE2 address derivation and requires
+> `zksolc`/`forge --zksync`. The Mailbox/IGP above are correct; the deployed HyperlaneOracle address
+> will not match other chains' deterministic addresses.

--- a/script/HyperlaneOracle.s.sol
+++ b/script/HyperlaneOracle.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Script } from "forge-std/Script.sol";
+
+import { HyperlaneOracle } from "../src/integrations/oracles/hyperlane/HyperlaneOracle.sol";
+
+/// @notice Deploys a HyperlaneOracle bound to the chain's Hyperlane Mailbox.
+///
+/// Deployed with `customHook = address(0)` and `ism = address(0)` so it falls back to the
+/// Mailbox's DEFAULT hook and DEFAULT ISM. Do NOT pass a custom ISM/hook address unless you
+/// have confirmed it has deployed code on this chain — a codeless ISM silently breaks
+/// Hyperlane message verification (delivery never completes).
+///
+/// Uses CREATE2 (`salt: bytes32(0)`), matching script/WormholeOracle.s.sol. The address is
+/// determined by the CREATE2 factory + salt + bytecode + constructor args, so it is deterministic
+/// PER CHAIN but NOT shared across chains (the `mailbox` arg differs per chain). Dry-run each chain
+/// to record its predicted address before broadcasting.
+///
+/// Usage:
+///   forge script script/HyperlaneOracle.s.sol:DeployHyperlaneOracle \
+///     --sig 'deploy(address)' <MAILBOX> \
+///     --rpc-url <RPC> --account deployer --broadcast
+contract DeployHyperlaneOracle is Script {
+    function deploy(
+        address mailbox
+    ) external returns (HyperlaneOracle oracle) {
+        require(mailbox != address(0), "mailbox=0");
+
+        vm.broadcast();
+        oracle = new HyperlaneOracle{ salt: bytes32(0) }(mailbox, address(0), address(0));
+    }
+}


### PR DESCRIPTION
## Description

Adds a `## HyperlaneOracle` section to `DEPLOYMENTS.md` documenting, per mainnet chain, the
Hyperlane **Mailbox**, **IGP**, **domain**, and the deployed **HyperlaneOracle** address. Also adds
`script/HyperlaneOracle.s.sol` — a Forge script (modeled on `script/WormholeOracle.s.sol`) that
deploys `HyperlaneOracle` bound to a chain's Mailbox using the mailbox **default hook + default ISM**
(`customHook = ism = 0x0`).

Mailbox/IGP/domain values are taken from the canonical `hyperlane-xyz/hyperlane-registry` and each
was cross-verified against a second source (Hyperlane docs / block-explorer label / on-chain
`localDomain()` + `quoteGasPayment()`). `domainId == chainId` on all 10 mainnets, so the base
`HyperlaneOracle` (identity chain-id) is used — `HyperlaneOracleMapped` is not required.

## Related Issues

<!-- Relates to #___ / Closes #___ — fill if an issue exists -->

## Third-Party Integration Checklist

N/A — documentation + a deploy script for the **existing** Hyperlane integration. No new external
library imports, no new dependencies in `foundry.toml`; the HyperlaneOracle contracts/interfaces
already live in `src/integrations/oracles/hyperlane/`.

## Additional Notes

- `customHook = ism = 0x0` is intentional: it uses the Mailbox default ISM. An earlier deploy used a
  custom ISM address with no on-chain code, which silently broke message verification — this avoids
  that class of bug.
- Newly deployed: Arbitrum, Base, Optimism, Linea, Scroll, BSC, Polygon — via CREATE2 from
  `0xCc2ACDd7eF3e9841d42E00199D4cF5bcdCa77a7e`, each on-chain-verified (`localDomain`/`MAILBOX` correct,
  `hook`/`ism` == `0x0`, mailbox `defaultIsm` has code).
- Source-verified on the scanners: Arbitrum, Base, Optimism, Linea, BSC, Polygon. Scroll is verified
  via Scrollscan's own API (chain id 534352 isn't on the Etherscan-V2 multichain list).
- Ethereum + Katana were already live (deployed earlier via plain CREATE) and match the production
  solver config.
- ZkSync Era is the only chain still pending — ZK Stack tooling / non-standard CREATE2 derivation —
  marked `_pending deploy_` in the table; it will follow in a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment guide with oracle deployment details across supported blockchain networks, including deployment addresses and configuration information
  * Added comprehensive per-chain deployment specifications with network-specific deployment methods and configuration details
  * Included address mapping for all supported chains and deployment-specific notes for unique network implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->